### PR TITLE
Add modals, collapsible benefits, and company field

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,3 +5,11 @@
 - [ ] Email or push reminders for benefits that are about to expire.
 - [ ] Import/export functionality for moving data between environments.
 - [ ] Automated tests for the FastAPI services and Vue components.
+
+## Frontend polish
+
+- [x] Add semiannual options to benefits.
+- [x] Benefits box should be collapsible and expandable.
+- [x] Add benefit should be popup dialog.
+- [x] Add credit card should be popup dialog.
+- [x] Add company name to card (Chase, Amex, etc.).

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -16,6 +16,20 @@ def init_db() -> None:
     """Create database tables if they do not already exist."""
 
     SQLModel.metadata.create_all(engine)
+    ensure_company_name_column()
+
+
+def ensure_company_name_column() -> None:
+    """Backfill the ``company_name`` column for older databases."""
+
+    with engine.connect() as connection:
+        existing_columns = {
+            row[1] for row in connection.exec_driver_sql("PRAGMA table_info(creditcard)")
+        }
+        if "company_name" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE creditcard ADD COLUMN company_name VARCHAR NOT NULL DEFAULT ''"
+            )
 
 
 def get_session() -> Iterator[Session]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -139,6 +139,7 @@ def build_card_response(session: Session, card: CreditCard) -> CreditCardWithBen
     return CreditCardWithBenefits(
         id=card.id,
         card_name=card.card_name,
+        company_name=card.company_name,
         last_four=card.last_four,
         account_name=card.account_name,
         annual_fee=card.annual_fee,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -12,6 +12,7 @@ class BenefitFrequency(str, Enum):
 
     monthly = "monthly"
     quarterly = "quarterly"
+    semiannual = "semiannual"
     yearly = "yearly"
 
 
@@ -20,6 +21,11 @@ class CreditCard(SQLModel, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
     card_name: str = Field(index=True)
+    company_name: str = Field(
+        default="",
+        index=True,
+        description="Card issuer or bank name",
+    )
     last_four: str = Field(min_length=4, max_length=4, description="Last four digits")
     account_name: str = Field(index=True, description="Account holder or user account identifier")
     annual_fee: float = Field(ge=0)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -45,6 +45,7 @@ class BenefitRead(BenefitBase):
 
 class CreditCardBase(SQLModel):
     card_name: str
+    company_name: str
     last_four: str = Field(min_length=4, max_length=4)
     account_name: str
     annual_fee: float = Field(ge=0)
@@ -57,6 +58,7 @@ class CreditCardCreate(CreditCardBase):
 
 class CreditCardUpdate(SQLModel):
     card_name: Optional[str] = None
+    company_name: Optional[str] = None
     last_four: Optional[str] = Field(default=None, min_length=4, max_length=4)
     account_name: Optional[str] = None
     annual_fee: Optional[float] = Field(default=None, ge=0)

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -86,13 +86,6 @@ textarea {
   border-radius: 999px;
 }
 
-.annual-fee {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  color: #475569;
-}
-
 .value-bar {
   position: relative;
   height: 12px;
@@ -271,6 +264,32 @@ textarea:focus {
   color: #111827;
 }
 
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.section-description {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.section-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.section-header .section-title {
+  margin-bottom: 0;
+}
+
 .empty-state {
   text-align: center;
   color: #64748b;
@@ -278,6 +297,41 @@ textarea:focus {
   border: 2px dashed rgba(148, 163, 184, 0.35);
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.75);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.primary-button.small {
+  padding: 0.4rem 0.85rem;
+  font-size: 0.9rem;
+  box-shadow: 0 12px 20px rgba(99, 102, 241, 0.3);
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: #6366f1;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.link-button:hover {
+  background-color: rgba(99, 102, 241, 0.12);
+  color: #4f46e5;
+}
+
+.link-button.inline {
+  padding: 0;
+  border-radius: 0;
+  font: inherit;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/components/BaseModal.vue
+++ b/frontend/src/components/BaseModal.vue
@@ -1,0 +1,129 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  open: {
+    type: Boolean,
+    default: false
+  },
+  title: {
+    type: String,
+    default: ''
+  }
+})
+
+const emit = defineEmits(['close'])
+
+const titleId = `modal-${Math.random().toString(36).slice(2, 10)}`
+const labelledBy = computed(() => (props.title ? titleId : undefined))
+</script>
+
+<template>
+  <teleport to="body">
+    <div v-if="open" class="modal-backdrop" @click.self="emit('close')">
+      <div
+        class="modal-panel"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="labelledBy"
+        tabindex="-1"
+      >
+        <header class="modal-header">
+          <div class="modal-header__content">
+            <slot name="header">
+              <h2 v-if="title" :id="titleId" class="modal-title">{{ title }}</h2>
+            </slot>
+          </div>
+          <button class="icon-button" type="button" aria-label="Close dialog" @click="emit('close')">
+            ×
+          </button>
+        </header>
+        <section class="modal-body">
+          <slot />
+        </section>
+        <footer v-if="$slots.footer" class="modal-footer">
+          <slot name="footer" />
+        </footer>
+      </div>
+    </div>
+  </teleport>
+</template>
+
+<style scoped>
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(2px);
+  z-index: 1000;
+}
+
+.modal-panel {
+  width: min(520px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border-radius: 20px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.25);
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+  gap: 1rem;
+}
+
+.modal-header__content {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.icon-button {
+  background: none;
+  border: none;
+  color: #475569;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease;
+}
+
+.icon-button:hover {
+  background-color: rgba(148, 163, 184, 0.2);
+}
+
+.modal-body {
+  padding: 1.5rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem 1.5rem;
+  border-top: 1px solid rgba(226, 232, 240, 0.8);
+}
+</style>

--- a/frontend/src/components/CreditCardList.vue
+++ b/frontend/src/components/CreditCardList.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   },
   frequencies: {
     type: Array,
-    default: () => ['monthly', 'quarterly', 'yearly']
+    default: () => ['monthly', 'quarterly', 'semiannual', 'yearly']
   }
 })
 


### PR DESCRIPTION
## Summary
- add a company_name column to credit cards, expose it through the API, and expand benefit frequencies to include a semiannual option
- create a reusable BaseModal component and switch the add-card and add-benefit flows to modal dialogs with improved styling
- make the benefits list collapsible, surface company names in card headers, and document the completed tasks in TODO.md

## Testing
- npm ci
- npm run build
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d3c4c74c80832ea9e2ffbfa0ff62cc