### PR TITLE
Add incremental and cumulative benefit tracking plus card templates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,17 @@
         - [x] Chase Aeroplan
         - [x] Amex Platinum
         - [x] Capitoal One Venture X
+- [ ] History
+    - [ ] Each Credit UI Card should be showing the current year
+    - [ ] The current year is defined as either the time year bound be the AF due date or the calander year
+    - [ ] Each year will contain a list of benefits that applied to that year and those benefits will track the use history for that year
+    - [ ] Add option on card to set AF year or caldner year
+    - [ ] Add edit pencil icon to top rigt corner of cards and open update dialog box to edit credit card
+    - [ ] to the left of the pencil icon add a graph icon, hover will show history
+    - [ ] the histroy icon will open a new popup that will display a credit UI Card for each year that histroy is available for
+- [ ] Benefits should have an edit icon in the top right that opens a dialog to edit the benefit
+- [ ] recurring benefits will also have a histoy icon that will show a pop dialog with benefit UI card for each time window in that Credit card year.
+- [ ] the monthly, quartly and semiannual options should default the expiration dates unless a differnt date is provided (end of month, middle of year, quartarly dates, etc,) annual should have option to reset on year of on AF
 
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,28 +6,28 @@
 - [x] Add benefit should be popup dialog.
 - [x] Add credit card should be popup dialog.
 - [x] Add company name to card (Chase, Amex, etc.).
-- [ ] Add incremental options to benefit (not all used at once)
-    - [ ] should create a list of uses(find a better name) (add names, date and value)
-    - [ ] view history , click and show table of histroy in popup
-- [ ] Add cumulative benefit type
-    - [ ] no intial value
-    - [ ] add a use (find a better name)  by hitting a button (add names, date and value)
-    - [ ] view history , click and show table of histroy in popup
-- [ ] Preconfigured Cards 
-    - [ ] in backend/data/creditcards/*.json
-    - [ ] create schema to store card types (Amex Platinum) and preconfigured benefits and AF fee
-    - [ ] Cards tp start with
-        - [ ] Chase Southwest Premiere Business 
-        - [ ] Chase Ink preferred  
-        - [ ] Chase Freedom
-        - [ ] Chase Southwest Premiere
-        - [ ] Chase IHG Premiere
-        - [ ] Chase Marriot Boundless
-        - [ ] Chase Sapphire Reserve
-        - [ ] hase United Club Car
-        - [ ] Chase Aeroplan
-        - [ ] Amex Platinum
-        - [ ] Capitoal One Venture X
+- [x] Add incremental options to benefit (not all used at once)
+    - [x] should create a list of uses(find a better name) (add names, date and value)
+    - [x] view history , click and show table of histroy in popup
+- [x] Add cumulative benefit type
+    - [x] no intial value
+    - [x] add a use (find a better name)  by hitting a button (add names, date and value)
+    - [x] view history , click and show table of histroy in popup
+- [x] Preconfigured Cards 
+    - [x] in backend/data/creditcards/*.json
+    - [x] create schema to store card types (Amex Platinum) and preconfigured benefits and AF fee
+    - [x] Cards tp start with
+        - [x] Chase Southwest Premiere Business 
+        - [x] Chase Ink preferred  
+        - [x] Chase Freedom
+        - [x] Chase Southwest Premiere
+        - [x] Chase IHG Premiere
+        - [x] Chase Marriot Boundless
+        - [x] Chase Sapphire Reserve
+        - [x] hase United Club Car
+        - [x] Chase Aeroplan
+        - [x] Amex Platinum
+        - [x] Capitoal One Venture X
 
 
 

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional, Sequence, Tuple
 
+from sqlalchemy import func
 from sqlmodel import Session, select
 
-from .models import Benefit, CreditCard
+from .models import Benefit, BenefitRedemption, BenefitType, CreditCard
 from .schemas import (
     BenefitCreate,
+    BenefitRedemptionCreate,
     BenefitUpdate,
     BenefitUsageUpdate,
     CreditCardCreate,
@@ -48,24 +50,44 @@ def get_credit_card(session: Session, card_id: int) -> Optional[CreditCard]:
 
 
 def create_benefit(session: Session, card: CreditCard, payload: BenefitCreate) -> Benefit:
-    benefit = Benefit(**payload.model_dump(), credit_card_id=card.id)
+    data = payload.model_dump()
+    value = data.pop("value", None)
+    benefit = Benefit(
+        **data,
+        credit_card_id=card.id,
+        value=value if value is not None else 0,
+    )
     session.add(benefit)
     session.commit()
     session.refresh(benefit)
+    sync_incremental_usage_status(session, benefit)
     return benefit
 
 
 def update_benefit(session: Session, benefit: Benefit, payload: BenefitUpdate) -> Benefit:
     update_data = payload.model_dump(exclude_unset=True)
-    for key, value in update_data.items():
-        setattr(benefit, key, value)
-    if update_data.get("is_used") is not None and update_data["is_used"]:
-        benefit.used_at = benefit.used_at or datetime.utcnow()
-    elif update_data.get("is_used") is not None and not update_data["is_used"]:
+    value = update_data.pop("value", None)
+    is_used = update_data.pop("is_used", None)
+    new_type = update_data.get("type")
+
+    if new_type and new_type != benefit.type:
+        benefit.is_used = False
         benefit.used_at = None
+
+    for key, item in update_data.items():
+        setattr(benefit, key, item)
+
+    if value is not None:
+        benefit.value = value
+
+    if is_used is not None and benefit.type == BenefitType.standard:
+        benefit.is_used = is_used
+        benefit.used_at = datetime.utcnow() if is_used else None
+
     session.add(benefit)
     session.commit()
     session.refresh(benefit)
+    sync_incremental_usage_status(session, benefit)
     return benefit
 
 
@@ -85,3 +107,63 @@ def get_benefit(session: Session, benefit_id: int) -> Optional[Benefit]:
 def list_benefits_for_card(session: Session, card_id: int) -> List[Benefit]:
     statement = select(Benefit).where(Benefit.credit_card_id == card_id)
     return session.exec(statement).all()
+
+
+def create_benefit_redemption(
+    session: Session, benefit: Benefit, payload: BenefitRedemptionCreate
+) -> BenefitRedemption:
+    redemption = BenefitRedemption(
+        **payload.model_dump(),
+        benefit_id=benefit.id,
+    )
+    session.add(redemption)
+    session.commit()
+    session.refresh(redemption)
+    sync_incremental_usage_status(session, benefit)
+    return redemption
+
+
+def list_benefit_redemptions(session: Session, benefit_id: int) -> List[BenefitRedemption]:
+    statement = (
+        select(BenefitRedemption)
+        .where(BenefitRedemption.benefit_id == benefit_id)
+        .order_by(BenefitRedemption.occurred_on.desc(), BenefitRedemption.id.desc())
+    )
+    return session.exec(statement).all()
+
+
+def redemption_summary_for_benefits(
+    session: Session, benefit_ids: Sequence[int]
+) -> Dict[int, Tuple[float, int]]:
+    if not benefit_ids:
+        return {}
+    statement = (
+        select(
+            BenefitRedemption.benefit_id,
+            func.coalesce(func.sum(BenefitRedemption.amount), 0),
+            func.count(BenefitRedemption.id),
+        )
+        .where(BenefitRedemption.benefit_id.in_(benefit_ids))
+        .group_by(BenefitRedemption.benefit_id)
+    )
+    results = session.exec(statement).all()
+    return {benefit_id: (float(total), int(count)) for benefit_id, total, count in results}
+
+
+def sync_incremental_usage_status(session: Session, benefit: Benefit | int) -> None:
+    if isinstance(benefit, int):
+        benefit_obj = session.get(Benefit, benefit)
+    else:
+        benefit_obj = benefit
+    if not benefit_obj or benefit_obj.type != BenefitType.incremental:
+        return
+
+    totals = redemption_summary_for_benefits(session, [benefit_obj.id])
+    total_amount = totals.get(benefit_obj.id, (0.0, 0))[0]
+    should_be_used = benefit_obj.value > 0 and total_amount >= benefit_obj.value
+    if benefit_obj.is_used != should_be_used:
+        benefit_obj.is_used = should_be_used
+        benefit_obj.used_at = datetime.utcnow() if should_be_used else None
+        session.add(benefit_obj)
+        session.commit()
+        session.refresh(benefit_obj)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -17,6 +17,7 @@ def init_db() -> None:
 
     SQLModel.metadata.create_all(engine)
     ensure_company_name_column()
+    ensure_benefit_type_column()
 
 
 def ensure_company_name_column() -> None:
@@ -29,6 +30,23 @@ def ensure_company_name_column() -> None:
         if "company_name" not in existing_columns:
             connection.exec_driver_sql(
                 "ALTER TABLE creditcard ADD COLUMN company_name VARCHAR NOT NULL DEFAULT ''"
+            )
+
+
+def ensure_benefit_type_column() -> None:
+    """Ensure benefit tables contain new tracking metadata columns."""
+
+    with engine.connect() as connection:
+        existing_columns = {
+            row[1] for row in connection.exec_driver_sql("PRAGMA table_info(benefit)")
+        }
+        if "type" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE benefit ADD COLUMN type VARCHAR NOT NULL DEFAULT 'standard'"
+            )
+        if "value" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE benefit ADD COLUMN value FLOAT NOT NULL DEFAULT 0"
             )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional, Tuple
 
 from fastapi import Depends, FastAPI, HTTPException, Response, status
 from fastapi.middleware.cors import CORSMiddleware
@@ -8,16 +8,20 @@ from sqlmodel import Session
 
 from . import crud
 from .database import get_session, init_db
-from .models import Benefit, BenefitFrequency, CreditCard
+from .models import Benefit, BenefitFrequency, BenefitType, CreditCard
 from .schemas import (
     BenefitCreate,
+    BenefitRedemptionCreate,
+    BenefitRedemptionRead,
     BenefitRead,
     BenefitUpdate,
     BenefitUsageUpdate,
     CreditCardCreate,
     CreditCardUpdate,
     CreditCardWithBenefits,
+    PreconfiguredCardRead,
 )
+from .preconfigured import load_preconfigured_cards
 
 app = FastAPI(title="CreditWatch", version="0.1.0")
 
@@ -43,6 +47,11 @@ def healthcheck() -> dict[str, str]:
 @app.get("/api/frequencies", response_model=List[str])
 def get_frequencies() -> List[str]:
     return [freq.value for freq in BenefitFrequency]
+
+
+@app.get("/api/preconfigured/cards", response_model=List[PreconfiguredCardRead])
+def get_preconfigured_cards() -> List[PreconfiguredCardRead]:
+    return load_preconfigured_cards()
 
 
 @app.get("/api/cards", response_model=List[CreditCardWithBenefits])
@@ -95,7 +104,9 @@ def add_benefit(
     card = require_card(session, card_id)
     benefit = crud.create_benefit(session, card, payload)
     session.refresh(benefit)
-    return BenefitRead.model_validate(benefit, from_attributes=True)
+    return build_benefit_read(
+        benefit, crud.redemption_summary_for_benefits(session, [benefit.id]).get(benefit.id)
+    )
 
 
 @app.put("/api/benefits/{benefit_id}", response_model=BenefitRead)
@@ -104,7 +115,10 @@ def update_benefit(
 ) -> BenefitRead:
     benefit = require_benefit(session, benefit_id)
     updated = crud.update_benefit(session, benefit, payload)
-    return BenefitRead.model_validate(updated, from_attributes=True)
+    return build_benefit_read(
+        updated,
+        crud.redemption_summary_for_benefits(session, [updated.id]).get(updated.id),
+    )
 
 
 @app.post("/api/benefits/{benefit_id}/usage", response_model=BenefitRead)
@@ -112,8 +126,47 @@ def set_benefit_usage(
     benefit_id: int, payload: BenefitUsageUpdate, session: Session = Depends(get_session)
 ) -> BenefitRead:
     benefit = require_benefit(session, benefit_id)
+    if benefit.type != BenefitType.standard:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Usage toggles are only supported for standard benefits.",
+        )
     updated = crud.set_benefit_usage(session, benefit, payload)
-    return BenefitRead.model_validate(updated, from_attributes=True)
+    return build_benefit_read(
+        updated,
+        crud.redemption_summary_for_benefits(session, [updated.id]).get(updated.id),
+    )
+
+
+@app.get(
+    "/api/benefits/{benefit_id}/redemptions",
+    response_model=List[BenefitRedemptionRead],
+)
+def list_benefit_redemptions(
+    benefit_id: int, session: Session = Depends(get_session)
+) -> List[BenefitRedemptionRead]:
+    benefit = require_benefit(session, benefit_id)
+    redemptions = crud.list_benefit_redemptions(session, benefit.id)
+    return [
+        BenefitRedemptionRead.model_validate(redemption, from_attributes=True)
+        for redemption in redemptions
+    ]
+
+
+@app.post(
+    "/api/benefits/{benefit_id}/redemptions",
+    response_model=BenefitRedemptionRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_benefit_redemption(
+    benefit_id: int,
+    payload: BenefitRedemptionCreate,
+    session: Session = Depends(get_session),
+) -> BenefitRedemptionRead:
+    benefit = require_benefit(session, benefit_id)
+    created = crud.create_benefit_redemption(session, benefit, payload)
+    session.refresh(created)
+    return BenefitRedemptionRead.model_validate(created, from_attributes=True)
 
 
 @app.delete(
@@ -130,12 +183,18 @@ def delete_benefit(benefit_id: int, session: Session = Depends(get_session)) -> 
 
 def build_card_response(session: Session, card: CreditCard) -> CreditCardWithBenefits:
     raw_benefits = crud.list_benefits_for_card(session, card.id)
-    benefits = [
-        BenefitRead.model_validate(benefit, from_attributes=True)
+    benefit_ids = [benefit.id for benefit in raw_benefits]
+    redemption_summary = crud.redemption_summary_for_benefits(session, benefit_ids)
+    benefits: List[BenefitRead] = [
+        build_benefit_read(benefit, redemption_summary.get(benefit.id))
         for benefit in raw_benefits
     ]
-    potential_value = sum(benefit.value for benefit in benefits)
-    utilized_value = sum(benefit.value for benefit in benefits if benefit.is_used)
+    potential_value = 0.0
+    utilized_value = 0.0
+    for benefit in benefits:
+        potential, utilized = compute_benefit_totals(benefit)
+        potential_value += potential
+        utilized_value += utilized
     return CreditCardWithBenefits(
         id=card.id,
         card_name=card.card_name,
@@ -166,3 +225,42 @@ def require_benefit(session: Session, benefit_id: int) -> Benefit:
             status_code=status.HTTP_404_NOT_FOUND, detail="Benefit not found"
         )
     return benefit
+
+
+def build_benefit_read(
+    benefit: Benefit, redemption_summary: Tuple[float, int] | None
+) -> BenefitRead:
+    total, count = redemption_summary or (0.0, 0)
+    remaining: Optional[float]
+    if benefit.type == BenefitType.incremental:
+        remaining = max(benefit.value - total, 0)
+    else:
+        remaining = None
+    return BenefitRead(
+        id=benefit.id,
+        credit_card_id=benefit.credit_card_id,
+        name=benefit.name,
+        description=benefit.description,
+        frequency=benefit.frequency,
+        type=benefit.type,
+        value=benefit.value,
+        expiration_date=benefit.expiration_date,
+        is_used=benefit.is_used,
+        used_at=benefit.used_at,
+        redemption_total=total,
+        redemption_count=count,
+        remaining_value=remaining,
+    )
+
+
+def compute_benefit_totals(benefit: BenefitRead) -> Tuple[float, float]:
+    if benefit.type == BenefitType.standard:
+        potential = benefit.value
+        utilized = benefit.value if benefit.is_used else 0.0
+    elif benefit.type == BenefitType.incremental:
+        potential = benefit.value
+        utilized = min(benefit.redemption_total, benefit.value)
+    else:
+        potential = benefit.redemption_total
+        utilized = benefit.redemption_total
+    return potential, utilized

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -16,6 +16,14 @@ class BenefitFrequency(str, Enum):
     yearly = "yearly"
 
 
+class BenefitType(str, Enum):
+    """Different tracking behaviours for a benefit."""
+
+    standard = "standard"
+    incremental = "incremental"
+    cumulative = "cumulative"
+
+
 class CreditCard(SQLModel, table=True):
     """Credit card stored in the system."""
 
@@ -40,8 +48,20 @@ class Benefit(SQLModel, table=True):
     name: str
     description: Optional[str] = None
     frequency: BenefitFrequency
-    value: float = Field(ge=0)
+    type: BenefitType = Field(default=BenefitType.standard)
+    value: float = Field(default=0, ge=0)
     expiration_date: Optional[date] = None
     is_used: bool = Field(default=False)
     used_at: Optional[datetime] = None
+
+
+class BenefitRedemption(SQLModel, table=True):
+    """Individual redemption or usage entry for a benefit."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    benefit_id: int = Field(foreign_key="benefit.id", index=True)
+    label: str
+    amount: float = Field(ge=0)
+    occurred_on: date = Field(default_factory=date.today)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
 

--- a/backend/app/preconfigured.py
+++ b/backend/app/preconfigured.py
@@ -1,0 +1,29 @@
+"""Utility helpers for loading preconfigured card templates."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import List
+
+from .schemas import PreconfiguredCardRead
+
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data" / "creditcards"
+
+
+@lru_cache
+def load_preconfigured_cards() -> List[PreconfiguredCardRead]:
+    """Return the list of preconfigured credit card templates."""
+
+    if not DATA_DIR.exists():
+        return []
+
+    cards: List[PreconfiguredCardRead] = []
+    for path in sorted(DATA_DIR.glob("*.json")):
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        cards.append(PreconfiguredCardRead.model_validate(payload))
+    return cards
+

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -3,28 +3,38 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import List, Optional
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, model_validator
 from sqlmodel import Field, SQLModel
 
-from .models import BenefitFrequency
+from .models import BenefitFrequency, BenefitType
 
 
 class BenefitBase(SQLModel):
     name: str
     description: Optional[str] = None
     frequency: BenefitFrequency
-    value: float = Field(ge=0)
+    type: BenefitType = Field(default=BenefitType.standard)
+    value: Optional[float] = Field(default=None, ge=0)
     expiration_date: Optional[date] = None
 
 
 class BenefitCreate(BenefitBase):
-    pass
+    @model_validator(mode="after")
+    def validate_value(cls, values: "BenefitCreate") -> "BenefitCreate":  # type: ignore[name-defined]
+        if values.type != BenefitType.cumulative and (values.value is None or values.value <= 0):
+            raise ValueError(
+                "A positive value is required for standard and incremental benefits."
+            )
+        if values.type == BenefitType.cumulative and values.value not in (None, 0):
+            raise ValueError("Cumulative benefits should not define an initial value.")
+        return values
 
 
 class BenefitUpdate(SQLModel):
     name: Optional[str] = None
     description: Optional[str] = None
     frequency: Optional[BenefitFrequency] = None
+    type: Optional[BenefitType] = None
     value: Optional[float] = Field(default=None, ge=0)
     expiration_date: Optional[date] = None
     is_used: Optional[bool] = None
@@ -37,8 +47,30 @@ class BenefitUsageUpdate(SQLModel):
 class BenefitRead(BenefitBase):
     id: int
     credit_card_id: int
+    value: float = Field(default=0, ge=0)
     is_used: bool
     used_at: Optional[datetime] = None
+    redemption_total: float = Field(default=0, ge=0)
+    redemption_count: int = Field(default=0, ge=0)
+    remaining_value: Optional[float] = Field(default=None, ge=0)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class BenefitRedemptionBase(SQLModel):
+    label: str
+    amount: float = Field(gt=0)
+    occurred_on: date = Field(default_factory=date.today)
+
+
+class BenefitRedemptionCreate(BenefitRedemptionBase):
+    pass
+
+
+class BenefitRedemptionRead(BenefitRedemptionBase):
+    id: int
+    benefit_id: int
+    created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -79,3 +111,20 @@ class CreditCardWithBenefits(CreditCardRead):
     net_position: float
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class PreconfiguredBenefitRead(SQLModel):
+    name: str
+    description: Optional[str] = None
+    frequency: BenefitFrequency
+    type: BenefitType = Field(default=BenefitType.standard)
+    value: Optional[float] = Field(default=None, ge=0)
+
+
+class PreconfiguredCardRead(SQLModel):
+    slug: str
+    card_type: str
+    company_name: str
+    annual_fee: float = Field(ge=0)
+    benefits: List[PreconfiguredBenefitRead]
+

--- a/backend/data/creditcards/amex-platinum.json
+++ b/backend/data/creditcards/amex-platinum.json
@@ -1,0 +1,35 @@
+{
+  "slug": "amex-platinum",
+  "card_type": "The Platinum Card\u00ae from American Express",
+  "company_name": "American Express",
+  "annual_fee": 695,
+  "benefits": [
+    {
+      "name": "Uber Cash",
+      "description": "$15 monthly credits plus $35 in December for rides or eats.",
+      "frequency": "monthly",
+      "type": "incremental",
+      "value": 200
+    },
+    {
+      "name": "Saks Fifth Avenue credits",
+      "description": "$50 credits twice per year at Saks Fifth Avenue.",
+      "frequency": "semiannual",
+      "type": "incremental",
+      "value": 100
+    },
+    {
+      "name": "Airline incidental credits",
+      "description": "$200 annual airline fee credit.",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 200
+    },
+    {
+      "name": "Amex Offers",
+      "description": "Track cumulative savings from Amex Offers applied to the card.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    }
+  ]
+}

--- a/backend/data/creditcards/capital-one-venture-x.json
+++ b/backend/data/creditcards/capital-one-venture-x.json
@@ -1,0 +1,35 @@
+{
+  "slug": "capital-one-venture-x",
+  "card_type": "Capital One Venture X Rewards Credit Card",
+  "company_name": "Capital One",
+  "annual_fee": 395,
+  "benefits": [
+    {
+      "name": "Capital One Travel credit",
+      "description": "$300 annual credit for bookings made through Capital One Travel.",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 300
+    },
+    {
+      "name": "Anniversary miles bonus",
+      "description": "10,000 anniversary miles each account anniversary (valued at 1\u00a2 per mile).",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 100
+    },
+    {
+      "name": "Cell phone protection",
+      "description": "Coverage for damaged or stolen phones when you pay your bill with the card.",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 800
+    },
+    {
+      "name": "Capital One offers",
+      "description": "Track statement credits earned from Capital One Offers.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    }
+  ]
+}

--- a/backend/data/creditcards/chase-aeroplan.json
+++ b/backend/data/creditcards/chase-aeroplan.json
@@ -1,0 +1,28 @@
+{
+  "slug": "chase-aeroplan",
+  "card_type": "Aeroplan\u00ae Credit Card",
+  "company_name": "Chase",
+  "annual_fee": 95,
+  "benefits": [
+    {
+      "name": "Maple Leaf Lounge passes",
+      "description": "Two lounge passes deposited after $15k spend.",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 100
+    },
+    {
+      "name": "Aeroplan statement credit",
+      "description": "$100 credit for Air Canada purchases made on the card.",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 100
+    },
+    {
+      "name": "Aeroplan bonuses",
+      "description": "Track milestone rewards and Elite Status boost earnings.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    }
+  ]
+}

--- a/backend/data/creditcards/chase-freedom.json
+++ b/backend/data/creditcards/chase-freedom.json
@@ -1,0 +1,28 @@
+{
+  "slug": "chase-freedom",
+  "card_type": "Chase Freedom\u00ae",
+  "company_name": "Chase",
+  "annual_fee": 0,
+  "benefits": [
+    {
+      "name": "5% rotating categories",
+      "description": "Track the cash back earned each quarter in the rotating bonus categories.",
+      "frequency": "quarterly",
+      "type": "incremental",
+      "value": 75
+    },
+    {
+      "name": "Shop Through Chase deals",
+      "description": "Cash back earned from limited-time merchant offers.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Purchase protection",
+      "description": "Extended warranty and purchase protection coverage valued annually.",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 100
+    }
+  ]
+}

--- a/backend/data/creditcards/chase-ihg-premier.json
+++ b/backend/data/creditcards/chase-ihg-premier.json
@@ -1,0 +1,28 @@
+{
+  "slug": "chase-ihg-premier",
+  "card_type": "IHG\u00ae Rewards Premier Credit Card",
+  "company_name": "Chase",
+  "annual_fee": 99,
+  "benefits": [
+    {
+      "name": "Free night certificate",
+      "description": "Track the annual free night certificate (up to 40k points).",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 200
+    },
+    {
+      "name": "IHG statement credits",
+      "description": "Quarterly statement credits toward IHG purchases.",
+      "frequency": "quarterly",
+      "type": "incremental",
+      "value": 100
+    },
+    {
+      "name": "IHG promotions",
+      "description": "Log savings from targeted IHG offers and promotions.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    }
+  ]
+}

--- a/backend/data/creditcards/chase-ink-preferred.json
+++ b/backend/data/creditcards/chase-ink-preferred.json
@@ -1,0 +1,28 @@
+{
+  "slug": "chase-ink-preferred",
+  "card_type": "Ink Business Preferred\u00ae Credit Card",
+  "company_name": "Chase",
+  "annual_fee": 95,
+  "benefits": [
+    {
+      "name": "Cell phone protection claims",
+      "description": "Coverage for damaged or stolen phones purchased on the card (max $600 per claim).",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 600
+    },
+    {
+      "name": "Shipping purchase credits",
+      "description": "Track savings from UPS, USPS, and FedEx purchases credited back by promotions.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Travel protections",
+      "description": "Trip cancellation and delay coverage valued as a one-time yearly benefit.",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 150
+    }
+  ]
+}

--- a/backend/data/creditcards/chase-marriott-boundless.json
+++ b/backend/data/creditcards/chase-marriott-boundless.json
@@ -1,0 +1,28 @@
+{
+  "slug": "chase-marriott-boundless",
+  "card_type": "Marriott Bonvoy Boundless\u00ae Credit Card",
+  "company_name": "Chase",
+  "annual_fee": 95,
+  "benefits": [
+    {
+      "name": "Free night certificate",
+      "description": "35,000-point free night certificate each anniversary.",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 200
+    },
+    {
+      "name": "Marriott statement credits",
+      "description": "Track $25 monthly dining credits from Marriott properties.",
+      "frequency": "monthly",
+      "type": "incremental",
+      "value": 300
+    },
+    {
+      "name": "Marriott offers",
+      "description": "Capture targeted Amex or Chase offers applied to the card.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    }
+  ]
+}

--- a/backend/data/creditcards/chase-sapphire-reserve.json
+++ b/backend/data/creditcards/chase-sapphire-reserve.json
@@ -1,0 +1,35 @@
+{
+  "slug": "chase-sapphire-reserve",
+  "card_type": "Chase Sapphire Reserve\u00ae",
+  "company_name": "Chase",
+  "annual_fee": 550,
+  "benefits": [
+    {
+      "name": "Annual travel credit",
+      "description": "$300 travel credit that resets each cardmember year.",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 300
+    },
+    {
+      "name": "DoorDash credits",
+      "description": "$5 monthly DoorDash credits (DoorDash and Caviar orders).",
+      "frequency": "monthly",
+      "type": "incremental",
+      "value": 60
+    },
+    {
+      "name": "Lyft Pink membership",
+      "description": "Annual valuation of the included Lyft Pink All Access membership.",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 199
+    },
+    {
+      "name": "Chase Offers",
+      "description": "Record savings from Chase Offers applied to Sapphire Reserve purchases.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    }
+  ]
+}

--- a/backend/data/creditcards/chase-southwest-premier-business.json
+++ b/backend/data/creditcards/chase-southwest-premier-business.json
@@ -1,0 +1,28 @@
+{
+  "slug": "chase-southwest-premier-business",
+  "card_type": "Southwest\u00ae Rapid Rewards\u00ae Premier Business Credit Card",
+  "company_name": "Chase",
+  "annual_fee": 99,
+  "benefits": [
+    {
+      "name": "Anniversary points bonus",
+      "description": "6,000 Rapid Rewards points deposited on each card anniversary.",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 90
+    },
+    {
+      "name": "Travel credits",
+      "description": "Annual statement credits for Wi-Fi and in-flight purchases.",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 100
+    },
+    {
+      "name": "Southwest offers",
+      "description": "Track ad-hoc savings earned from limited-time Southwest offers.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    }
+  ]
+}

--- a/backend/data/creditcards/chase-southwest-premier.json
+++ b/backend/data/creditcards/chase-southwest-premier.json
@@ -1,0 +1,28 @@
+{
+  "slug": "chase-southwest-premier",
+  "card_type": "Southwest\u00ae Rapid Rewards\u00ae Premier Credit Card",
+  "company_name": "Chase",
+  "annual_fee": 99,
+  "benefits": [
+    {
+      "name": "Anniversary points bonus",
+      "description": "6,000 Rapid Rewards points on each account anniversary.",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 90
+    },
+    {
+      "name": "In-flight Wi-Fi credits",
+      "description": "Track statement credits for Southwest Wi-Fi purchases.",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 60
+    },
+    {
+      "name": "Companion pass progress",
+      "description": "Add redemptions that count toward the Southwest Companion Pass.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    }
+  ]
+}

--- a/backend/data/creditcards/chase-united-club.json
+++ b/backend/data/creditcards/chase-united-club.json
@@ -1,0 +1,35 @@
+{
+  "slug": "chase-united-club",
+  "card_type": "United Club\u2122 Infinite Card",
+  "company_name": "Chase",
+  "annual_fee": 525,
+  "benefits": [
+    {
+      "name": "United Club membership",
+      "description": "Full United Club lounge access valuation.",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 550
+    },
+    {
+      "name": "TravelBank cash credits",
+      "description": "$125 TravelBank cash credited each account year.",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 125
+    },
+    {
+      "name": "TSA PreCheck or Global Entry",
+      "description": "Credit for TSA PreCheck or Global Entry enrollment.",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 100
+    },
+    {
+      "name": "United offers",
+      "description": "Track promotional savings from United cardmember offers.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    }
+  ]
+}

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -138,6 +138,11 @@ textarea {
   color: #b91c1c;
 }
 
+.tag.info {
+  background: rgba(59, 130, 246, 0.12);
+  color: #2563eb;
+}
+
 .benefits-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
@@ -192,6 +197,34 @@ textarea {
   justify-content: space-between;
   align-items: center;
   gap: 0.5rem;
+}
+
+.helper-text {
+  margin: 0.5rem 0 1rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+
+.history-table th,
+.history-table td {
+  padding: 0.6rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+.history-table tbody tr:nth-child(even) {
+  background-color: rgba(241, 245, 249, 0.5);
+}
+
+.history-loading {
+  font-size: 0.9rem;
+  color: #475569;
 }
 
 .primary-button {

--- a/frontend/src/components/BenefitCard.vue
+++ b/frontend/src/components/BenefitCard.vue
@@ -8,13 +8,31 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['toggle', 'delete'])
+const emit = defineEmits(['toggle', 'delete', 'add-redemption', 'view-history'])
 
-const statusTag = computed(() =>
-  props.benefit.is_used
-    ? { label: 'Utilized', tone: 'success' }
-    : { label: 'Available', tone: 'warning' }
-)
+const typeLabel = computed(() => {
+  const type = props.benefit.type || 'standard'
+  return type.charAt(0).toUpperCase() + type.slice(1)
+})
+
+const statusTag = computed(() => {
+  const type = props.benefit.type
+  if (type === 'standard') {
+    return props.benefit.is_used
+      ? { label: 'Utilized', tone: 'success' }
+      : { label: 'Available', tone: 'warning' }
+  }
+  if (type === 'incremental') {
+    if (props.benefit.redemption_total >= props.benefit.value) {
+      return { label: 'Completed', tone: 'success' }
+    }
+    if (props.benefit.redemption_total > 0) {
+      return { label: 'In progress', tone: 'info' }
+    }
+    return { label: 'Not started', tone: 'warning' }
+  }
+  return { label: 'Tracking', tone: 'info' }
+})
 
 const expirationLabel = computed(() => {
   if (!props.benefit.expiration_date) {
@@ -26,6 +44,21 @@ const expirationLabel = computed(() => {
     year: 'numeric'
   }).format(new Date(props.benefit.expiration_date))
 })
+
+const redemptionSummary = computed(() => {
+  if (props.benefit.type === 'incremental') {
+    const used = props.benefit.redemption_total || 0
+    const remaining = props.benefit.remaining_value ?? Math.max(props.benefit.value - used, 0)
+    return `Used $${used.toFixed(2)} of $${props.benefit.value.toFixed(2)} (${remaining <= 0 ? 'complete' : `$${remaining.toFixed(2)} remaining`})`
+  }
+  if (props.benefit.type === 'cumulative') {
+    const used = props.benefit.redemption_total || 0
+    return `Recorded $${used.toFixed(2)} this cycle`
+  }
+  return `Worth $${props.benefit.value.toFixed(2)}`
+})
+
+const showHistoryButton = computed(() => props.benefit.type !== 'standard' || props.benefit.redemption_count > 0)
 </script>
 
 <template>
@@ -33,6 +66,7 @@ const expirationLabel = computed(() => {
     <header class="benefit-header">
       <div>
         <div class="benefit-name">{{ benefit.name }}</div>
+        <div class="benefit-type">{{ typeLabel }}</div>
         <div class="benefit-frequency">{{ benefit.frequency }}</div>
       </div>
       <div class="tag" :class="statusTag.tone">
@@ -43,19 +77,40 @@ const expirationLabel = computed(() => {
     <section class="benefit-body">
       <p v-if="benefit.description">{{ benefit.description }}</p>
       <p class="benefit-expiration">Expires: {{ expirationLabel }}</p>
+      <p class="benefit-progress">{{ redemptionSummary }}</p>
     </section>
 
     <footer class="benefit-footer">
       <div>
-        <strong>${{ benefit.value.toFixed(2) }}</strong>
+        <strong v-if="benefit.type !== 'cumulative'">
+          ${{ benefit.value.toFixed(2) }}
+        </strong>
+        <strong v-else>${{ benefit.redemption_total.toFixed(2) }}</strong>
       </div>
       <div class="benefit-actions">
         <button
+          v-if="benefit.type === 'standard'"
           class="primary-button secondary"
           type="button"
           @click="emit('toggle', !benefit.is_used)"
         >
           {{ benefit.is_used ? 'Reset' : 'Mark used' }}
+        </button>
+        <button
+          v-if="benefit.type !== 'standard'"
+          class="primary-button secondary"
+          type="button"
+          @click="emit('add-redemption', benefit)"
+        >
+          Add redemption
+        </button>
+        <button
+          v-if="showHistoryButton"
+          class="primary-button secondary"
+          type="button"
+          @click="emit('view-history', benefit)"
+        >
+          View history
         </button>
         <button class="primary-button danger" type="button" @click="emit('delete')">
           Remove
@@ -75,6 +130,18 @@ const expirationLabel = computed(() => {
   font-size: 0.85rem;
   margin: 0;
   color: #94a3b8;
+}
+
+.benefit-type {
+  font-size: 0.75rem;
+  color: #0ea5e9;
+  font-weight: 600;
+}
+
+.benefit-progress {
+  font-size: 0.85rem;
+  margin: 0.25rem 0 0;
+  color: #0f172a;
 }
 
 strong {

--- a/frontend/src/components/CreditCardList.vue
+++ b/frontend/src/components/CreditCardList.vue
@@ -16,7 +16,9 @@ const emit = defineEmits([
   'add-benefit',
   'toggle-benefit',
   'delete-benefit',
-  'delete-card'
+  'delete-card',
+  'add-redemption',
+  'view-history'
 ])
 </script>
 
@@ -31,6 +33,8 @@ const emit = defineEmits([
       @toggle-benefit="emit('toggle-benefit', $event)"
       @delete-benefit="emit('delete-benefit', $event)"
       @delete-card="emit('delete-card', $event)"
+      @add-redemption="emit('add-redemption', $event)"
+      @view-history="emit('view-history', $event)"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- add a benefit type enum, redemption tracking API routes, and schema updates for incremental and cumulative benefits
- extend the Vue UI to capture benefit type, record redemptions, view history, and apply preconfigured card templates
- ship JSON templates for popular cards and ensure the database backfills new benefit columns

## Testing
- npm run build
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d3c84c6800832eba56424bdcd7286a