### PR TITLE
Implement admin board and benefit enhancements

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,13 +39,13 @@
 - [x] Benefits should have an edit icon in the top right that opens a dialog to edit the benefit
 - [x] recurring benefits will also have a histoy icon that will show a pop dialog with benefit UI card for each time window in that Credit card year.
 - [x] the monthly, quartly and semiannual options should default the expiration dates unless a differnt date is provided (end of month, middle of year, quartarly dates, etc,) annual should have option to reset on year of on AF
-- [ ] Create a Header  Bar and then add add an admin page to the board. The admin board should be able to edit and add to prebuilt credit card configutations. these changes should update the .json files
-- [ ] Update the (edit,delete, history) icons to have a flat one color icon look
-- [ ] Benefits that are recurring should track the total value of the year and also the value for that month
-- [ ] The "View History"  should just be a hambuger icon
-- [ ] the benefits should take up two columns in a credit UI card
-- [ ] when adding a benefit add descripts for standard and incremental , just like there is for cumulative
-- [ ] For cumulative add an optional expected value
+- [x] Create a Header  Bar and then add add an admin page to the board. The admin board should be able to edit and add to prebuilt credit card configutations. these changes should update the .json files
+- [x] Update the (edit,delete, history) icons to have a flat one color icon look
+- [x] Benefits that are recurring should track the total value of the year and also the value for that month
+- [x] The "View History"  should just be a hambuger icon
+- [x] the benefits should take up two columns in a credit UI card
+- [x] when adding a benefit add descripts for standard and incremental , just like there is for cumulative
+- [x] For cumulative add an optional expected value
 
 
 

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from sqlalchemy import func
@@ -166,7 +166,10 @@ def list_benefit_redemptions(session: Session, benefit_id: int) -> List[BenefitR
 
 
 def redemption_summary_for_benefits(
-    session: Session, benefit_ids: Sequence[int]
+    session: Session,
+    benefit_ids: Sequence[int],
+    start_date: date | None = None,
+    end_date: date | None = None,
 ) -> Dict[int, Tuple[float, int]]:
     if not benefit_ids:
         return {}
@@ -179,6 +182,10 @@ def redemption_summary_for_benefits(
         .where(BenefitRedemption.benefit_id.in_(benefit_ids))
         .group_by(BenefitRedemption.benefit_id)
     )
+    if start_date is not None:
+        statement = statement.where(BenefitRedemption.occurred_on >= start_date)
+    if end_date is not None:
+        statement = statement.where(BenefitRedemption.occurred_on < end_date)
     results = session.exec(statement).all()
     return {benefit_id: (float(total), int(count)) for benefit_id, total, count in results}
 

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -69,17 +69,23 @@ def update_benefit(session: Session, benefit: Benefit, payload: BenefitUpdate) -
     update_data = payload.model_dump(exclude_unset=True)
     value = update_data.pop("value", None)
     is_used = update_data.pop("is_used", None)
+    expected_value = update_data.pop("expected_value", None)
     new_type = update_data.get("type")
 
     if new_type and new_type != benefit.type:
         benefit.is_used = False
         benefit.used_at = None
+        if new_type != BenefitType.cumulative:
+            benefit.expected_value = None
 
     for key, item in update_data.items():
         setattr(benefit, key, item)
 
     if value is not None:
         benefit.value = value
+
+    if "expected_value" in payload.model_fields_set:
+        benefit.expected_value = expected_value
 
     if is_used is not None and benefit.type == BenefitType.standard:
         benefit.is_used = is_used

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -49,6 +49,10 @@ def ensure_benefit_type_column() -> None:
             connection.exec_driver_sql(
                 "ALTER TABLE benefit ADD COLUMN value FLOAT NOT NULL DEFAULT 0"
             )
+        if "expected_value" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE benefit ADD COLUMN expected_value FLOAT"
+            )
 
 
 def ensure_card_year_tracking_column() -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
+import calendar
+from datetime import date, timedelta
+from typing import Dict, List, Optional, Tuple
 
 from fastapi import Depends, FastAPI, HTTPException, Response, status
 from fastapi.middleware.cors import CORSMiddleware
@@ -8,7 +10,14 @@ from sqlmodel import Session
 
 from . import crud
 from .database import get_session, init_db
-from .models import Benefit, BenefitFrequency, BenefitRedemption, BenefitType, CreditCard
+from .models import (
+    Benefit,
+    BenefitFrequency,
+    BenefitRedemption,
+    BenefitType,
+    CreditCard,
+    YearTrackingMode,
+)
 from .schemas import (
     BenefitCreate,
     BenefitRedemptionCreate,
@@ -157,9 +166,7 @@ def add_benefit(
     card = require_card(session, card_id)
     benefit = crud.create_benefit(session, card, payload)
     session.refresh(benefit)
-    return build_benefit_read(
-        benefit, crud.redemption_summary_for_benefits(session, [benefit.id]).get(benefit.id)
-    )
+    return build_enriched_benefit(session, benefit, card)
 
 
 @app.put("/api/benefits/{benefit_id}", response_model=BenefitRead)
@@ -168,10 +175,7 @@ def update_benefit(
 ) -> BenefitRead:
     benefit = require_benefit(session, benefit_id)
     updated = crud.update_benefit(session, benefit, payload)
-    return build_benefit_read(
-        updated,
-        crud.redemption_summary_for_benefits(session, [updated.id]).get(updated.id),
-    )
+    return build_enriched_benefit(session, updated)
 
 
 @app.post("/api/benefits/{benefit_id}/usage", response_model=BenefitRead)
@@ -185,10 +189,7 @@ def set_benefit_usage(
             detail="Usage toggles are only supported for standard benefits.",
         )
     updated = crud.set_benefit_usage(session, benefit, payload)
-    return build_benefit_read(
-        updated,
-        crud.redemption_summary_for_benefits(session, [updated.id]).get(updated.id),
-    )
+    return build_enriched_benefit(session, updated)
 
 
 @app.get(
@@ -263,12 +264,37 @@ def delete_benefit(benefit_id: int, session: Session = Depends(get_session)) -> 
 
 def build_card_response(session: Session, card: CreditCard) -> CreditCardWithBenefits:
     raw_benefits = crud.list_benefits_for_card(session, card.id)
-    benefit_ids = [benefit.id for benefit in raw_benefits]
-    redemption_summary = crud.redemption_summary_for_benefits(session, benefit_ids)
-    benefits: List[BenefitRead] = [
-        build_benefit_read(benefit, redemption_summary.get(benefit.id))
-        for benefit in raw_benefits
-    ]
+    metrics = gather_benefit_metrics(session, card, raw_benefits)
+    overall_totals = metrics["overall"]
+    cycle_totals = metrics["cycle"]
+    window_totals = metrics["window_totals"]
+    window_info = metrics["window_info"]
+    cycle_label = metrics["cycle_label"]
+
+    benefits: List[BenefitRead] = []
+    for benefit in raw_benefits:
+        frequency = benefit.frequency
+        summary = overall_totals.get(benefit.id)
+        cycle_total = cycle_totals.get(benefit.id, (0.0, 0))[0]
+        info = window_info.get(frequency, {})
+        window_label = info.get("label") or cycle_label
+        frequency_totals = window_totals.get(frequency, {})
+        window_entry = frequency_totals.get(benefit.id)
+        if frequency == BenefitFrequency.yearly:
+            current_window_total = cycle_total
+        else:
+            current_window_total = window_entry[0] if window_entry else 0.0
+        benefits.append(
+            build_benefit_read(
+                benefit,
+                summary,
+                cycle_total,
+                cycle_label,
+                current_window_total,
+                window_label,
+            )
+        )
+
     potential_value = 0.0
     utilized_value = 0.0
     for benefit in benefits:
@@ -316,14 +342,185 @@ def require_redemption(session: Session, redemption_id: int) -> BenefitRedemptio
         )
     return redemption
 
+def _safe_day(year: int, month: int, day: int) -> int:
+    _, last_day = calendar.monthrange(year, month)
+    return min(day, last_day)
+
+
+def _add_months(value: date, months: int) -> date:
+    month_index = value.month - 1 + months
+    year = value.year + month_index // 12
+    month = month_index % 12 + 1
+    day = _safe_day(year, month, value.day)
+    return date(year, month, day)
+
+
+def _compute_card_cycle_bounds(
+    card: CreditCard, reference: date | None = None
+) -> Tuple[date, date]:
+    today = reference or date.today()
+    if card.year_tracking_mode == YearTrackingMode.anniversary:
+        due_month = card.fee_due_date.month
+        due_day = card.fee_due_date.day
+        cycle_end = date(today.year, due_month, _safe_day(today.year, due_month, due_day))
+        if cycle_end <= today:
+            cycle_end = date(
+                today.year + 1, due_month, _safe_day(today.year + 1, due_month, due_day)
+            )
+        cycle_start = date(
+            cycle_end.year - 1,
+            due_month,
+            _safe_day(cycle_end.year - 1, due_month, due_day),
+        )
+    else:
+        cycle_start = date(today.year, 1, 1)
+        cycle_end = date(today.year + 1, 1, 1)
+    return cycle_start, cycle_end
+
+
+def _format_cycle_label(card: CreditCard, cycle_start: date, cycle_end: date) -> str:
+    if card.year_tracking_mode == YearTrackingMode.calendar:
+        return str(cycle_start.year)
+    inclusive_end = cycle_end - timedelta(days=1)
+    return f"{cycle_start.year}-{inclusive_end.year}"
+
+
+def _format_range_label(window_start: date, window_end: date) -> str:
+    inclusive_end = window_end - timedelta(days=1)
+    start_label = f"{window_start.strftime('%b')} {window_start.day}"
+    end_label = f"{inclusive_end.strftime('%b')} {inclusive_end.day}"
+    if window_start.year == inclusive_end.year:
+        return f"{start_label} – {end_label}"
+    return f"{start_label} {window_start.year} – {end_label} {inclusive_end.year}"
+
+
+def _window_prefix(frequency: BenefitFrequency, index: int) -> str:
+    if frequency == BenefitFrequency.monthly:
+        return f"Month {index}"
+    if frequency == BenefitFrequency.quarterly:
+        return f"Quarter {index}"
+    if frequency == BenefitFrequency.semiannual:
+        return f"Half {index}"
+    return "Year"
+
+
+def _current_frequency_window(
+    cycle_start: date,
+    cycle_end: date,
+    frequency: BenefitFrequency,
+    reference: date | None = None,
+) -> Tuple[date, date, str, int]:
+    reference_date = reference or date.today()
+    months_map = {
+        BenefitFrequency.monthly: 1,
+        BenefitFrequency.quarterly: 3,
+        BenefitFrequency.semiannual: 6,
+        BenefitFrequency.yearly: 12,
+    }
+    months = months_map.get(frequency)
+    if not months:
+        label = f"{_window_prefix(frequency, 1)} · {_format_range_label(cycle_start, cycle_end)}"
+        return cycle_start, cycle_end, label, 1
+    windows: List[Tuple[date, date, str, int]] = []
+    index = 1
+    cursor = cycle_start
+    while cursor < cycle_end:
+        window_end = _add_months(cursor, months)
+        if window_end > cycle_end:
+            window_end = cycle_end
+        label = f"{_window_prefix(frequency, index)} · {_format_range_label(cursor, window_end)}"
+        windows.append((cursor, window_end, label, index))
+        cursor = window_end
+        index += 1
+    if not windows:
+        label = f"{_window_prefix(frequency, 1)} · {_format_range_label(cycle_start, cycle_end)}"
+        return cycle_start, cycle_end, label, 1
+    for window_start, window_end, label, idx in windows:
+        if window_start <= reference_date < window_end:
+            return window_start, window_end, label, idx
+    return windows[-1]
+
+
+def gather_benefit_metrics(
+    session: Session, card: CreditCard, benefits: List[Benefit]
+) -> Dict[str, object]:
+    benefit_ids = [benefit.id for benefit in benefits if benefit.id is not None]
+    cycle_start, cycle_end = _compute_card_cycle_bounds(card)
+    cycle_label = _format_cycle_label(card, cycle_start, cycle_end)
+    overall_totals = crud.redemption_summary_for_benefits(session, benefit_ids)
+    cycle_totals = crud.redemption_summary_for_benefits(
+        session, benefit_ids, cycle_start, cycle_end
+    )
+    frequency_groups: Dict[BenefitFrequency, List[int]] = {}
+    for benefit in benefits:
+        frequency_groups.setdefault(benefit.frequency, []).append(benefit.id)
+    window_totals: Dict[BenefitFrequency, Dict[int, Tuple[float, int]]] = {}
+    window_info: Dict[BenefitFrequency, Dict[str, object]] = {}
+    for frequency in BenefitFrequency:
+        window_start, window_end, label, _ = _current_frequency_window(
+            cycle_start, cycle_end, frequency
+        )
+        window_info[frequency] = {
+            "start": window_start,
+            "end": window_end,
+            "label": label,
+        }
+        ids = frequency_groups.get(frequency, [])
+        if ids and window_start < window_end:
+            window_totals[frequency] = crud.redemption_summary_for_benefits(
+                session, ids, window_start, window_end
+            )
+        else:
+            window_totals[frequency] = {}
+    return {
+        "overall": overall_totals,
+        "cycle": cycle_totals,
+        "window_totals": window_totals,
+        "window_info": window_info,
+        "cycle_label": cycle_label,
+    }
+
+
+def build_enriched_benefit(
+    session: Session, benefit: Benefit, card: CreditCard | None = None
+) -> BenefitRead:
+    parent_card = card or require_card(session, benefit.credit_card_id)
+    metrics = gather_benefit_metrics(session, parent_card, [benefit])
+    summary = metrics["overall"].get(benefit.id)
+    cycle_total = metrics["cycle"].get(benefit.id, (0.0, 0))[0]
+    frequency = benefit.frequency
+    info = metrics["window_info"].get(frequency, {})
+    window_label = info.get("label") or metrics["cycle_label"]
+    window_entry = metrics["window_totals"].get(frequency, {}).get(benefit.id)
+    if frequency == BenefitFrequency.yearly:
+        current_window_total = cycle_total
+    else:
+        current_window_total = window_entry[0] if window_entry else 0.0
+    return build_benefit_read(
+        benefit,
+        summary,
+        cycle_total,
+        metrics["cycle_label"],
+        current_window_total,
+        window_label,
+    )
+
 
 def build_benefit_read(
-    benefit: Benefit, redemption_summary: Tuple[float, int] | None
+    benefit: Benefit,
+    redemption_summary: Tuple[float, int] | None,
+    cycle_total: float,
+    cycle_label: str,
+    window_total: float | None,
+    window_label: Optional[str],
 ) -> BenefitRead:
     total, count = redemption_summary or (0.0, 0)
+    cycle_value = float(cycle_total)
+    window_value = float(window_total) if window_total is not None else None
     remaining: Optional[float]
     if benefit.type == BenefitType.incremental:
-        remaining = max(benefit.value - total, 0)
+        target = float(benefit.value or 0)
+        remaining = max(target - cycle_value, 0)
     else:
         remaining = None
     return BenefitRead(
@@ -341,21 +538,22 @@ def build_benefit_read(
         redemption_total=total,
         redemption_count=count,
         remaining_value=remaining,
+        cycle_redemption_total=cycle_value,
+        cycle_label=cycle_label,
+        current_window_total=window_value,
+        current_window_label=window_label,
     )
 
 
 def compute_benefit_totals(benefit: BenefitRead) -> Tuple[float, float]:
+    cycle_total = float(benefit.cycle_redemption_total or 0)
     if benefit.type == BenefitType.standard:
-        potential = benefit.value
-        utilized = benefit.value if benefit.is_used else 0.0
+        potential = float(benefit.value or 0)
+        utilized = potential if benefit.is_used else 0.0
     elif benefit.type == BenefitType.incremental:
-        potential = benefit.value
-        utilized = min(benefit.redemption_total, benefit.value)
+        potential = float(benefit.value or 0)
+        utilized = min(cycle_total, potential)
     else:
-        potential = benefit.expected_value or benefit.redemption_total
-        utilized = (
-            min(benefit.redemption_total, potential)
-            if benefit.expected_value
-            else benefit.redemption_total
-        )
+        potential = float(benefit.expected_value or cycle_total)
+        utilized = min(cycle_total, potential) if benefit.expected_value else cycle_total
     return potential, utilized

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -61,6 +61,7 @@ class Benefit(SQLModel, table=True):
     frequency: BenefitFrequency
     type: BenefitType = Field(default=BenefitType.standard)
     value: float = Field(default=0, ge=0)
+    expected_value: Optional[float] = Field(default=None, ge=0)
     expiration_date: Optional[date] = None
     is_used: bool = Field(default=False)
     used_at: Optional[datetime] = None

--- a/backend/app/preconfigured.py
+++ b/backend/app/preconfigured.py
@@ -1,16 +1,51 @@
-"""Utility helpers for loading preconfigured card templates."""
+"""Utility helpers for loading and persisting preconfigured card templates."""
 
 from __future__ import annotations
 
 import json
+import re
 from functools import lru_cache
 from pathlib import Path
-from typing import List
+from typing import Any, Iterable, List
 
-from .schemas import PreconfiguredCardRead
+from .schemas import PreconfiguredCardRead, PreconfiguredCardWrite
 
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data" / "creditcards"
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _path_for_slug(slug: str) -> Path:
+    return DATA_DIR / f"{slug}.json"
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "card"
+
+
+def _serialise_benefit(payload: dict[str, Any]) -> dict[str, Any]:
+    cleaned = {key: value for key, value in payload.items() if value is not None}
+    if cleaned.get("type") == "cumulative":
+        cleaned.pop("value", None)
+    return cleaned
+
+
+def _serialise_card_payload(payload: PreconfiguredCardWrite, slug: str) -> dict[str, Any]:
+    data = payload.model_dump(exclude_none=True)
+    benefits: Iterable[dict[str, Any]] = data.get("benefits", [])
+    data["benefits"] = [_serialise_benefit(benefit) for benefit in benefits]
+    data["slug"] = slug
+    return data
+
+
+def _ensure_unique_slug(slug: str) -> str:
+    candidate = slug
+    counter = 2
+    while _path_for_slug(candidate).exists():
+        candidate = f"{slug}-{counter}"
+        counter += 1
+    return candidate
 
 
 @lru_cache
@@ -26,4 +61,66 @@ def load_preconfigured_cards() -> List[PreconfiguredCardRead]:
             payload = json.load(handle)
         cards.append(PreconfiguredCardRead.model_validate(payload))
     return cards
+
+
+def load_preconfigured_card(slug: str) -> PreconfiguredCardRead:
+    """Load a single preconfigured card template by slug."""
+
+    path = _path_for_slug(slug)
+    if not path.exists():
+        raise FileNotFoundError(slug)
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return PreconfiguredCardRead.model_validate(payload)
+
+
+def create_preconfigured_card(payload: PreconfiguredCardWrite) -> PreconfiguredCardRead:
+    """Persist a new preconfigured card template to disk."""
+
+    desired_slug = _slugify(payload.slug or payload.card_type)
+    slug = _ensure_unique_slug(desired_slug)
+    card_payload = _serialise_card_payload(payload, slug)
+    path = _path_for_slug(slug)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(card_payload, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    load_preconfigured_cards.cache_clear()
+    return PreconfiguredCardRead.model_validate(card_payload)
+
+
+def update_preconfigured_card(
+    slug: str, payload: PreconfiguredCardWrite
+) -> PreconfiguredCardRead:
+    """Update an existing template, optionally renaming its slug."""
+
+    original_path = _path_for_slug(slug)
+    if not original_path.exists():
+        raise FileNotFoundError(slug)
+
+    desired_slug = payload.slug or slug
+    new_slug = _slugify(desired_slug)
+    if new_slug != slug and _path_for_slug(new_slug).exists():
+        raise FileExistsError(new_slug)
+
+    card_payload = _serialise_card_payload(payload, new_slug)
+    new_path = _path_for_slug(new_slug)
+    with new_path.open("w", encoding="utf-8") as handle:
+        json.dump(card_payload, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+
+    if new_slug != slug:
+        original_path.unlink(missing_ok=True)
+
+    load_preconfigured_cards.cache_clear()
+    return PreconfiguredCardRead.model_validate(card_payload)
+
+
+def delete_preconfigured_card(slug: str) -> None:
+    """Remove a preconfigured card template from disk."""
+
+    path = _path_for_slug(slug)
+    if not path.exists():
+        raise FileNotFoundError(slug)
+    path.unlink()
+    load_preconfigured_cards.cache_clear()
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -57,6 +57,10 @@ class BenefitRead(BenefitBase):
     redemption_total: float = Field(default=0, ge=0)
     redemption_count: int = Field(default=0, ge=0)
     remaining_value: Optional[float] = Field(default=None, ge=0)
+    cycle_redemption_total: float = Field(default=0, ge=0)
+    cycle_label: Optional[str] = None
+    current_window_total: Optional[float] = Field(default=None, ge=0)
+    current_window_label: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/data/creditcards/amex-platinum.json
+++ b/backend/data/creditcards/amex-platinum.json
@@ -1,6 +1,6 @@
 {
   "slug": "amex-platinum",
-  "card_type": "The Platinum Card\u00ae from American Express",
+  "card_type": "The Platinum Card® from American Express",
   "company_name": "American Express",
   "annual_fee": 695,
   "benefits": [
@@ -28,6 +28,12 @@
     {
       "name": "Amex Offers",
       "description": "Track cumulative savings from Amex Offers applied to the card.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Points",
+      "description": "Track rewards points accrued throughout the year.",
       "frequency": "yearly",
       "type": "cumulative"
     }

--- a/backend/data/creditcards/capital-one-venture-x.json
+++ b/backend/data/creditcards/capital-one-venture-x.json
@@ -13,7 +13,7 @@
     },
     {
       "name": "Anniversary miles bonus",
-      "description": "10,000 anniversary miles each account anniversary (valued at 1\u00a2 per mile).",
+      "description": "10,000 anniversary miles each account anniversary (valued at 1¢ per mile).",
       "frequency": "yearly",
       "type": "standard",
       "value": 100
@@ -28,6 +28,12 @@
     {
       "name": "Capital One offers",
       "description": "Track statement credits earned from Capital One Offers.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Points",
+      "description": "Track rewards points accrued throughout the year.",
       "frequency": "yearly",
       "type": "cumulative"
     }

--- a/backend/data/creditcards/chase-aeroplan.json
+++ b/backend/data/creditcards/chase-aeroplan.json
@@ -1,6 +1,6 @@
 {
   "slug": "chase-aeroplan",
-  "card_type": "Aeroplan\u00ae Credit Card",
+  "card_type": "Aeroplan® Credit Card",
   "company_name": "Chase",
   "annual_fee": 95,
   "benefits": [
@@ -21,6 +21,12 @@
     {
       "name": "Aeroplan bonuses",
       "description": "Track milestone rewards and Elite Status boost earnings.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Points",
+      "description": "Track rewards points accrued throughout the year.",
       "frequency": "yearly",
       "type": "cumulative"
     }

--- a/backend/data/creditcards/chase-freedom.json
+++ b/backend/data/creditcards/chase-freedom.json
@@ -1,6 +1,6 @@
 {
   "slug": "chase-freedom",
-  "card_type": "Chase Freedom\u00ae",
+  "card_type": "Chase Freedom®",
   "company_name": "Chase",
   "annual_fee": 0,
   "benefits": [
@@ -23,6 +23,12 @@
       "frequency": "yearly",
       "type": "standard",
       "value": 100
+    },
+    {
+      "name": "Points",
+      "description": "Track rewards points accrued throughout the year.",
+      "frequency": "yearly",
+      "type": "cumulative"
     }
   ]
 }

--- a/backend/data/creditcards/chase-ihg-premier.json
+++ b/backend/data/creditcards/chase-ihg-premier.json
@@ -1,6 +1,6 @@
 {
   "slug": "chase-ihg-premier",
-  "card_type": "IHG\u00ae Rewards Premier Credit Card",
+  "card_type": "IHG® Rewards Premier Credit Card",
   "company_name": "Chase",
   "annual_fee": 99,
   "benefits": [
@@ -21,6 +21,12 @@
     {
       "name": "IHG promotions",
       "description": "Log savings from targeted IHG offers and promotions.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Points",
+      "description": "Track rewards points accrued throughout the year.",
       "frequency": "yearly",
       "type": "cumulative"
     }

--- a/backend/data/creditcards/chase-ink-preferred.json
+++ b/backend/data/creditcards/chase-ink-preferred.json
@@ -1,6 +1,6 @@
 {
   "slug": "chase-ink-preferred",
-  "card_type": "Ink Business Preferred\u00ae Credit Card",
+  "card_type": "Ink Business Preferred® Credit Card",
   "company_name": "Chase",
   "annual_fee": 95,
   "benefits": [
@@ -23,6 +23,12 @@
       "frequency": "yearly",
       "type": "standard",
       "value": 150
+    },
+    {
+      "name": "Points",
+      "description": "Track rewards points accrued throughout the year.",
+      "frequency": "yearly",
+      "type": "cumulative"
     }
   ]
 }

--- a/backend/data/creditcards/chase-marriott-boundless.json
+++ b/backend/data/creditcards/chase-marriott-boundless.json
@@ -1,6 +1,6 @@
 {
   "slug": "chase-marriott-boundless",
-  "card_type": "Marriott Bonvoy Boundless\u00ae Credit Card",
+  "card_type": "Marriott Bonvoy Boundless® Credit Card",
   "company_name": "Chase",
   "annual_fee": 95,
   "benefits": [
@@ -21,6 +21,12 @@
     {
       "name": "Marriott offers",
       "description": "Capture targeted Amex or Chase offers applied to the card.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Points",
+      "description": "Track rewards points accrued throughout the year.",
       "frequency": "yearly",
       "type": "cumulative"
     }

--- a/backend/data/creditcards/chase-sapphire-reserve.json
+++ b/backend/data/creditcards/chase-sapphire-reserve.json
@@ -1,6 +1,6 @@
 {
   "slug": "chase-sapphire-reserve",
-  "card_type": "Chase Sapphire Reserve\u00ae",
+  "card_type": "Chase Sapphire Reserve®",
   "company_name": "Chase",
   "annual_fee": 550,
   "benefits": [
@@ -28,6 +28,12 @@
     {
       "name": "Chase Offers",
       "description": "Record savings from Chase Offers applied to Sapphire Reserve purchases.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Points",
+      "description": "Track rewards points accrued throughout the year.",
       "frequency": "yearly",
       "type": "cumulative"
     }

--- a/backend/data/creditcards/chase-southwest-premier-business.json
+++ b/backend/data/creditcards/chase-southwest-premier-business.json
@@ -1,6 +1,6 @@
 {
   "slug": "chase-southwest-premier-business",
-  "card_type": "Southwest\u00ae Rapid Rewards\u00ae Premier Business Credit Card",
+  "card_type": "Southwest® Rapid Rewards® Premier Business Credit Card",
   "company_name": "Chase",
   "annual_fee": 99,
   "benefits": [
@@ -21,6 +21,12 @@
     {
       "name": "Southwest offers",
       "description": "Track ad-hoc savings earned from limited-time Southwest offers.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Points",
+      "description": "Track rewards points accrued throughout the year.",
       "frequency": "yearly",
       "type": "cumulative"
     }

--- a/backend/data/creditcards/chase-southwest-premier.json
+++ b/backend/data/creditcards/chase-southwest-premier.json
@@ -1,6 +1,6 @@
 {
   "slug": "chase-southwest-premier",
-  "card_type": "Southwest\u00ae Rapid Rewards\u00ae Premier Credit Card",
+  "card_type": "Southwest® Rapid Rewards® Premier Credit Card",
   "company_name": "Chase",
   "annual_fee": 99,
   "benefits": [
@@ -21,6 +21,12 @@
     {
       "name": "Companion pass progress",
       "description": "Add redemptions that count toward the Southwest Companion Pass.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Points",
+      "description": "Track rewards points accrued throughout the year.",
       "frequency": "yearly",
       "type": "cumulative"
     }

--- a/backend/data/creditcards/chase-united-club.json
+++ b/backend/data/creditcards/chase-united-club.json
@@ -1,6 +1,6 @@
 {
   "slug": "chase-united-club",
-  "card_type": "United Club\u2122 Infinite Card",
+  "card_type": "United Club™ Infinite Card",
   "company_name": "Chase",
   "annual_fee": 525,
   "benefits": [
@@ -28,6 +28,12 @@
     {
       "name": "United offers",
       "description": "Track promotional savings from United cardmember offers.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Points",
+      "description": "Track rewards points accrued throughout the year.",
       "frequency": "yearly",
       "type": "cumulative"
     }

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -16,6 +16,76 @@ body {
   background: radial-gradient(circle at top left, #e0f2fe, #f8fafc 55%);
 }
 
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background: rgba(15, 23, 42, 0.72);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  color: #f8fafc;
+}
+
+.header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.header-brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-width: 420px;
+}
+
+.brand-tagline {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(241, 245, 249, 0.8);
+}
+
+.header-nav {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.nav-button {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: #e2e8f0;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.nav-button:hover {
+  background-color: rgba(148, 163, 184, 0.2);
+}
+
+.nav-button.active {
+  background: #f8fafc;
+  color: #0f172a;
+  border-color: transparent;
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.app-main {
+  flex: 1;
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -51,6 +121,11 @@ button {
   transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
+.icon-button svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
 .icon-button:hover {
   background-color: rgba(99, 102, 241, 0.18);
   transform: translateY(-1px);
@@ -72,6 +147,11 @@ button {
   height: 2.2rem;
 }
 
+.icon-button.accent svg {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
 .icon-button.danger {
   background: linear-gradient(135deg, #f97316, #ef4444);
   color: #ffffff;
@@ -87,6 +167,19 @@ textarea {
   margin: 0 auto;
   padding: 2.5rem 1.5rem 4rem;
   max-width: 1200px;
+}
+
+.intro-section {
+  margin-bottom: 1rem;
+}
+
+.error-message {
+  margin-top: 2rem;
+  color: #b91c1c;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(254, 242, 242, 0.65);
 }
 
 .page-title {
@@ -105,6 +198,83 @@ textarea {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   gap: 1.5rem;
+}
+
+.admin-table-wrapper {
+  overflow-x: auto;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  border-radius: 16px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+}
+
+.admin-table th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #475569;
+  background: rgba(248, 250, 252, 0.85);
+}
+
+.admin-table tr:last-child td {
+  border-bottom: none;
+}
+
+.admin-table__name {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.admin-card-name {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.admin-card-slug {
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.admin-actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.actions-column {
+  width: 120px;
+}
+
+.admin-benefit-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.admin-benefit-card {
+  padding: 0.85rem;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  border-radius: 14px;
+  background: rgba(248, 250, 252, 0.75);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.admin-benefit-values {
+  align-items: center;
 }
 
 .card {
@@ -197,8 +367,14 @@ textarea {
 
 .benefits-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
+}
+
+@media (max-width: 900px) {
+  .benefits-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .benefit-card {

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -4,6 +4,7 @@
   font-weight: 400;
   color: #0f172a;
   background-color: #f1f5f9;
+  --benefit-card-min-height: 220px;
 }
 
 * {
@@ -196,7 +197,7 @@ textarea {
 
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(540px, 1fr));
   gap: 1.5rem;
 }
 
@@ -369,6 +370,10 @@ textarea {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
+  max-height: calc(var(--benefit-card-min-height) * 3 + 2rem);
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 0.25rem;
 }
 
 @media (max-width: 900px) {
@@ -386,6 +391,7 @@ textarea {
   gap: 0.75rem;
   border: 1px solid rgba(226, 232, 240, 0.9);
   box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  min-height: var(--benefit-card-min-height);
 }
 
 .benefit-card.used {

--- a/frontend/src/components/BenefitCard.vue
+++ b/frontend/src/components/BenefitCard.vue
@@ -55,14 +55,18 @@ const expirationLabel = computed(() => {
 const redemptionSummary = computed(() => {
   if (props.benefit.type === 'incremental') {
     const used = props.benefit.redemption_total || 0
-    const remaining = props.benefit.remaining_value ?? Math.max(props.benefit.value - used, 0)
-    return `Used $${used.toFixed(2)} of $${props.benefit.value.toFixed(2)} (${remaining <= 0 ? 'complete' : `$${remaining.toFixed(2)} remaining`})`
+    const target = Number(props.benefit.value ?? 0)
+    const remaining = props.benefit.remaining_value ?? Math.max(target - used, 0)
+    return `Used $${used.toFixed(2)} of $${target.toFixed(2)} (${remaining <= 0 ? 'complete' : `$${remaining.toFixed(2)} remaining`})`
   }
   if (props.benefit.type === 'cumulative') {
     const used = props.benefit.redemption_total || 0
+    if (props.benefit.expected_value != null) {
+      return `Recorded $${used.toFixed(2)} this cycle · Expected $${props.benefit.expected_value.toFixed(2)}`
+    }
     return `Recorded $${used.toFixed(2)} this cycle`
   }
-  return `Worth $${props.benefit.value.toFixed(2)}`
+  return `Worth $${Number(props.benefit.value ?? 0).toFixed(2)}`
 })
 
 const showHistoryButton = computed(
@@ -72,6 +76,48 @@ const showHistoryButton = computed(
 const isRecurringBenefit = computed(() =>
   ['monthly', 'quarterly', 'semiannual'].includes(props.benefit.frequency)
 )
+
+const occurrencesPerYear = {
+  monthly: 12,
+  quarterly: 4,
+  semiannual: 2,
+  yearly: 1
+}
+
+const frequencyLabels = {
+  monthly: 'month',
+  quarterly: 'quarter',
+  semiannual: 'half-year',
+  yearly: 'year'
+}
+
+const annualPotential = computed(() => {
+  const occurrences = occurrencesPerYear[props.benefit.frequency] || 1
+  if (props.benefit.type === 'cumulative') {
+    return props.benefit.expected_value ?? props.benefit.redemption_total ?? 0
+  }
+  const perPeriod = Number(props.benefit.value ?? 0)
+  return perPeriod * occurrences
+})
+
+const periodPotential = computed(() => {
+  const occurrences = occurrencesPerYear[props.benefit.frequency] || 1
+  if (!occurrences) {
+    return annualPotential.value
+  }
+  if (props.benefit.type === 'cumulative') {
+    return annualPotential.value / occurrences
+  }
+  return Number(props.benefit.value ?? 0)
+})
+
+const recurringCopy = computed(() => {
+  if (!isRecurringBenefit.value || !annualPotential.value) {
+    return ''
+  }
+  const label = frequencyLabels[props.benefit.frequency] || 'period'
+  return `Annual value $${annualPotential.value.toFixed(2)} • Per ${label} $${periodPotential.value.toFixed(2)}`
+})
 </script>
 
 <template>
@@ -94,7 +140,9 @@ const isRecurringBenefit = computed(() =>
             @click="emit('view-windows', benefit)"
             title="View recurring history"
           >
-            <span aria-hidden="true">📊</span>
+            <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M4 16h2V9H4v7zm5 0h2V4H9v12zm5 0h2v-5h-2v5z" />
+            </svg>
             <span class="sr-only">View recurring history</span>
           </button>
           <button
@@ -103,11 +151,15 @@ const isRecurringBenefit = computed(() =>
             @click="emit('edit', benefit)"
             title="Edit benefit"
           >
-            <span aria-hidden="true">✏️</span>
+            <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M15.58 2.42a1.5 1.5 0 0 0-2.12 0l-9 9V17h5.59l9-9a1.5 1.5 0 0 0 0-2.12zM7 15H5v-2l6.88-6.88 2 2z" />
+            </svg>
             <span class="sr-only">Edit benefit</span>
           </button>
           <button class="icon-button danger" type="button" @click="emit('delete')" title="Remove benefit">
-            <span aria-hidden="true">🗑️</span>
+            <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M7 3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1h3.5a.5.5 0 0 1 0 1h-.8l-.62 11a2 2 0 0 1-2 1.9H6.92a2 2 0 0 1-2-1.9L4.3 5H3.5a.5.5 0 0 1 0-1H7zm1 1h4V3H8zM6.3 5l.6 10.8a1 1 0 0 0 1 1h4.2a1 1 0 0 0 1-1L13.7 5z" />
+            </svg>
             <span class="sr-only">Remove benefit</span>
           </button>
         </div>
@@ -118,14 +170,22 @@ const isRecurringBenefit = computed(() =>
       <p v-if="benefit.description">{{ benefit.description }}</p>
       <p class="benefit-expiration">Expires: {{ expirationLabel }}</p>
       <p class="benefit-progress">{{ redemptionSummary }}</p>
+      <p v-if="recurringCopy" class="benefit-recurring">{{ recurringCopy }}</p>
     </section>
 
     <footer class="benefit-footer">
       <div>
         <strong v-if="benefit.type !== 'cumulative'">
-          ${{ benefit.value.toFixed(2) }}
+          ${{ Number(benefit.value ?? 0).toFixed(2) }}
         </strong>
-        <strong v-else>${{ benefit.redemption_total.toFixed(2) }}</strong>
+        <strong v-else>
+          <template v-if="benefit.expected_value != null">
+            Expected ${{ Number(benefit.expected_value).toFixed(2) }}
+          </template>
+          <template v-else>
+            ${{ benefit.redemption_total.toFixed(2) }} tracked
+          </template>
+        </strong>
       </div>
       <div class="benefit-actions">
         <button
@@ -145,16 +205,22 @@ const isRecurringBenefit = computed(() =>
           @click="emit('add-redemption', benefit)"
           title="Add redemption"
         >
-          <span aria-hidden="true">+</span>
+          <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M10 4a1 1 0 0 1 1 1v4h4a1 1 0 1 1 0 2h-4v4a1 1 0 1 1-2 0v-4H5a1 1 0 1 1 0-2h4V5a1 1 0 0 1 1-1z" />
+          </svg>
           <span class="sr-only">Add redemption</span>
         </button>
         <button
           v-if="showHistoryButton"
-          class="primary-button secondary"
+          class="icon-button ghost"
           type="button"
           @click="emit('view-history', benefit)"
+          title="View history"
         >
-          View history
+          <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <path stroke-linecap="round" d="M4 6h12M4 10h12M4 14h12" />
+          </svg>
+          <span class="sr-only">View history</span>
         </button>
       </div>
     </footer>
@@ -195,6 +261,12 @@ const isRecurringBenefit = computed(() =>
   font-size: 0.85rem;
   margin: 0.25rem 0 0;
   color: #0f172a;
+}
+
+.benefit-recurring {
+  font-size: 0.78rem;
+  margin: 0.1rem 0 0;
+  color: #6366f1;
 }
 
 strong {


### PR DESCRIPTION
## Summary
- Add optional expected value support for cumulative benefits and admin CRUD endpoints that persist cleaned template JSON on disk.
- Introduce a header-driven dashboard/admin split with UI to manage preconfigured templates and updated benefit forms (including expected value handling).
- Refresh benefit/card icons, apply the two-column layout, and surface recurring benefit copy with annual and per-period values.

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3e947dcc4832ead0c1ac5d9a43e5f