### PR TITLE
Compute recurring expirations and refine benefit UI

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -964,12 +964,6 @@ onMounted(async () => {
       <div class="container">
 
       <template v-if="!isAdminView">
-        <section class="section-card intro-section">
-          <h2 class="section-title">Add a credit card</h2>
-          <p class="section-description">
-            Keep your issuer, account, and fee details in one place so you always know a card's value.
-          </p>
-        </section>
 
         <section class="section-card">
           <h2 class="section-title">Portfolio overview</h2>

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -34,52 +34,53 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
-  padding: 1.25rem 1.5rem;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem;
 }
 
 .header-brand {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  max-width: 420px;
+  gap: 0.25rem;
+  max-width: 380px;
 }
 
 .brand-tagline {
   margin: 0;
-  font-size: 0.95rem;
-  color: rgba(241, 245, 249, 0.8);
+  font-size: 0.82rem;
+  color: rgba(241, 245, 249, 0.78);
 }
 
 .header-nav {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.5rem;
   align-items: center;
 }
 
 .nav-button {
   background: transparent;
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: none;
   color: #e2e8f0;
-  padding: 0.4rem 0.9rem;
-  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  border-radius: 6px;
   cursor: pointer;
-  transition: background-color 0.2s ease, border-color 0.2s ease;
+  font-size: 0.92rem;
+  font-weight: 500;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .nav-button:hover {
-  background-color: rgba(148, 163, 184, 0.2);
+  background-color: rgba(148, 163, 184, 0.22);
 }
 
 .nav-button.active {
-  background: #f8fafc;
-  color: #0f172a;
-  border-color: transparent;
+  background-color: rgba(255, 255, 255, 0.2);
+  color: #ffffff;
 }
 
 .header-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.5rem;
   align-items: center;
 }
 
@@ -112,50 +113,54 @@ button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 999px;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 6px;
   border: none;
-  background: rgba(99, 102, 241, 0.1);
-  color: #4f46e5;
+  background: transparent;
+  color: #475569;
   cursor: pointer;
-  transition: background-color 0.2s ease, transform 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
 .icon-button svg {
-  width: 1.1rem;
-  height: 1.1rem;
+  width: 0.95rem;
+  height: 0.95rem;
 }
 
 .icon-button:hover {
-  background-color: rgba(99, 102, 241, 0.18);
+  background-color: rgba(148, 163, 184, 0.18);
   transform: translateY(-1px);
 }
 
 .icon-button.ghost {
-  background: none;
-  color: #475569;
+  color: inherit;
 }
 
 .icon-button.ghost:hover {
-  background-color: rgba(148, 163, 184, 0.2);
+  background-color: rgba(148, 163, 184, 0.18);
 }
 
 .icon-button.accent {
   background: linear-gradient(135deg, #0ea5e9, #22d3ee);
   color: #ffffff;
-  width: 2.2rem;
-  height: 2.2rem;
+  width: 1.95rem;
+  height: 1.95rem;
+  border-radius: 999px;
 }
 
 .icon-button.accent svg {
-  width: 1.2rem;
-  height: 1.2rem;
+  width: 1.05rem;
+  height: 1.05rem;
 }
 
 .icon-button.danger {
-  background: linear-gradient(135deg, #f97316, #ef4444);
-  color: #ffffff;
+  background: transparent;
+  color: #dc2626;
+}
+
+.icon-button.danger:hover {
+  background-color: rgba(248, 113, 113, 0.18);
 }
 
 input,
@@ -166,12 +171,8 @@ textarea {
 
 .container {
   margin: 0 auto;
-  padding: 2.5rem 1.5rem 4rem;
+  padding: 2rem 1.5rem 4rem;
   max-width: 1200px;
-}
-
-.intro-section {
-  margin-bottom: 1rem;
 }
 
 .error-message {
@@ -184,9 +185,9 @@ textarea {
 }
 
 .page-title {
-  font-size: clamp(2rem, 3vw + 1rem, 3rem);
+  font-size: clamp(1.75rem, 2.5vw + 0.8rem, 2.5rem);
   font-weight: 700;
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.15rem;
   color: #0f172a;
 }
 
@@ -345,10 +346,10 @@ textarea {
 .tag {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.3rem;
   border-radius: 999px;
-  padding: 0.3rem 0.75rem;
-  font-size: 0.82rem;
+  padding: 0.22rem 0.6rem;
+  font-size: 0.75rem;
 }
 
 .tag.success {
@@ -610,6 +611,16 @@ textarea:focus {
   gap: 0.35rem;
   align-items: center;
   justify-content: flex-start;
+}
+
+.history-actions .icon-button {
+  width: 1.6rem;
+  height: 1.6rem;
+}
+
+.history-actions .icon-button svg {
+  width: 0.9rem;
+  height: 0.9rem;
 }
 
 .history-window-label {

--- a/frontend/src/components/BenefitCard.vue
+++ b/frontend/src/components/BenefitCard.vue
@@ -43,6 +43,25 @@ const statusTag = computed(() => {
   return { label: 'Tracking', tone: 'info' }
 })
 
+const timeWindowLabel = computed(() => {
+  if (props.benefit.current_window_label) {
+    return props.benefit.current_window_label
+  }
+  if (props.benefit.frequency === 'yearly') {
+    if (props.benefit.cycle_label) {
+      return props.benefit.cycle_label.includes('-')
+        ? `Cycle ${props.benefit.cycle_label}`
+        : `Year ${props.benefit.cycle_label}`
+    }
+    return 'Yearly cycle'
+  }
+  const frequency = props.benefit.frequency
+  if (!frequency) {
+    return ''
+  }
+  return frequency.charAt(0).toUpperCase() + frequency.slice(1)
+})
+
 const expirationLabel = computed(() => {
   if (!props.benefit.expiration_date) {
     return 'No expiration set'
@@ -140,46 +159,48 @@ const recurringPotentialCopy = computed(() => {
 <template>
   <article class="benefit-card" :class="{ used: benefit.is_used }">
     <header class="benefit-header">
-      <div>
+      <div class="benefit-header__primary">
         <div class="benefit-name">{{ benefit.name }}</div>
-        <div class="benefit-type">{{ typeLabel }}</div>
-        <div class="benefit-frequency">{{ benefit.frequency }}</div>
+        <div class="benefit-meta-row">
+          <div class="benefit-meta">
+            <span class="benefit-type">{{ typeLabel }}</span>
+            <span v-if="timeWindowLabel" class="benefit-window">{{ timeWindowLabel }}</span>
+          </div>
+          <div class="tag" :class="statusTag.tone">
+            <span>{{ statusTag.label }}</span>
+          </div>
+        </div>
       </div>
-      <div class="benefit-header__meta">
-        <div class="tag" :class="statusTag.tone">
-          <span>{{ statusTag.label }}</span>
-        </div>
-        <div class="benefit-icons">
-          <button
-            v-if="isRecurringBenefit"
-            class="icon-button ghost"
-            type="button"
-            @click="emit('view-windows', benefit)"
-            title="View recurring history"
-          >
-            <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path d="M4 16h2V9H4v7zm5 0h2V4H9v12zm5 0h2v-5h-2v5z" />
-            </svg>
-            <span class="sr-only">View recurring history</span>
-          </button>
-          <button
-            class="icon-button ghost"
-            type="button"
-            @click="emit('edit', benefit)"
-            title="Edit benefit"
-          >
-            <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path d="M15.58 2.42a1.5 1.5 0 0 0-2.12 0l-9 9V17h5.59l9-9a1.5 1.5 0 0 0 0-2.12zM7 15H5v-2l6.88-6.88 2 2z" />
-            </svg>
-            <span class="sr-only">Edit benefit</span>
-          </button>
-          <button class="icon-button danger" type="button" @click="emit('delete')" title="Remove benefit">
-            <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path d="M7 3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1h3.5a.5.5 0 0 1 0 1h-.8l-.62 11a2 2 0 0 1-2 1.9H6.92a2 2 0 0 1-2-1.9L4.3 5H3.5a.5.5 0 0 1 0-1H7zm1 1h4V3H8zM6.3 5l.6 10.8a1 1 0 0 0 1 1h4.2a1 1 0 0 0 1-1L13.7 5z" />
-            </svg>
-            <span class="sr-only">Remove benefit</span>
-          </button>
-        </div>
+      <div class="benefit-icons">
+        <button
+          v-if="isRecurringBenefit"
+          class="icon-button ghost"
+          type="button"
+          @click="emit('view-windows', benefit)"
+          title="View recurring history"
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M4 16h2V9H4v7zm5 0h2V4H9v12zm5 0h2v-5h-2v5z" />
+          </svg>
+          <span class="sr-only">View recurring history</span>
+        </button>
+        <button
+          class="icon-button ghost"
+          type="button"
+          @click="emit('edit', benefit)"
+          title="Edit benefit"
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M15.58 2.42a1.5 1.5 0 0 0-2.12 0l-9 9V17h5.59l9-9a1.5 1.5 0 0 0 0-2.12zM7 15H5v-2l6.88-6.88 2 2z" />
+          </svg>
+          <span class="sr-only">Edit benefit</span>
+        </button>
+        <button class="icon-button danger" type="button" @click="emit('delete')" title="Remove benefit">
+          <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M7 3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1h3.5a.5.5 0 0 1 0 1h-.8l-.62 11a2 2 0 0 1-2 1.9H6.92a2 2 0 0 1-2-1.9L4.3 5H3.5a.5.5 0 0 1 0-1H7zm1 1h4V3H8zM6.3 5l.6 10.8a1 1 0 0 0 1 1h4.2a1 1 0 0 0 1-1L13.7 5z" />
+          </svg>
+          <span class="sr-only">Remove benefit</span>
+        </button>
       </div>
     </header>
 
@@ -257,13 +278,53 @@ const recurringPotentialCopy = computed(() => {
 <style scoped>
 .benefit-icons {
   display: flex;
-  gap: 0.35rem;
+  gap: 0.3rem;
+  align-items: flex-start;
+}
+
+.benefit-icons .icon-button {
+  width: 1.6rem;
+  height: 1.6rem;
+}
+
+.benefit-icons .icon-button svg {
+  width: 0.9rem;
+  height: 0.9rem;
 }
 
 .benefit-actions {
   display: flex;
   gap: 0.5rem;
   align-items: center;
+}
+
+.benefit-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.benefit-header__primary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex: 1;
+}
+
+.benefit-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.benefit-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: #475569;
 }
 
 .benefit-expiration {
@@ -273,15 +334,17 @@ const recurringPotentialCopy = computed(() => {
 }
 
 .benefit-type {
-  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
   color: #0ea5e9;
   font-weight: 600;
+  font-size: 0.72rem;
 }
 
-.benefit-header__meta {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
+.benefit-window {
+  font-size: 0.72rem;
+  color: #64748b;
+  font-weight: 500;
 }
 
 .benefit-progress {


### PR DESCRIPTION
## Summary
- calculate default expiration dates for recurring benefits on the backend using the active cycle window so responses include an expiry even when none is stored
- align the benefit editor defaults with the backend by deriving monthly, quarterly, semiannual, and yearly expirations from the card’s cycle, and reorganize benefit headers so type/time and status share a row
- tighten the UI with a slimmer navigation bar, smaller action icons (including red trash-only delete buttons), and remove the introductory “Add a credit card” card from the dashboard

## Testing
- npm run build
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d416b8a548832ebdb30fcf48940159