### PR TITLE
Refresh preconfigured card benefits

### DIFF
--- a/backend/data/creditcards/amex-platinum.json
+++ b/backend/data/creditcards/amex-platinum.json
@@ -6,10 +6,24 @@
   "benefits": [
     {
       "name": "Uber Cash",
-      "description": "$15 monthly credits plus $35 in December for rides or eats.",
+      "description": "$15 in monthly Uber Cash plus a $35 boost in December for rides or eats.",
       "frequency": "monthly",
       "type": "incremental",
       "value": 200
+    },
+    {
+      "name": "Digital entertainment credit",
+      "description": "$20 in monthly credits toward eligible streaming and news subscriptions.",
+      "frequency": "monthly",
+      "type": "incremental",
+      "value": 240
+    },
+    {
+      "name": "Equinox credit",
+      "description": "Up to $300 in annual statement credits for eligible Equinox memberships.",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 300
     },
     {
       "name": "Saks Fifth Avenue credits",
@@ -19,11 +33,32 @@
       "value": 100
     },
     {
+      "name": "Prepaid hotel credit",
+      "description": "$200 statement credit for Fine Hotels + Resorts® or The Hotel Collection bookings made through Amex Travel.",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 200
+    },
+    {
       "name": "Airline incidental credits",
       "description": "$200 annual airline fee credit.",
       "frequency": "yearly",
       "type": "incremental",
       "value": 200
+    },
+    {
+      "name": "CLEAR® Plus credit",
+      "description": "Up to $189 back each year for CLEAR® Plus membership when charged to the card.",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 189
+    },
+    {
+      "name": "Walmart+ membership credit",
+      "description": "Monthly statement credits to offset Walmart+ membership dues (plus Paramount+ access).",
+      "frequency": "monthly",
+      "type": "incremental",
+      "value": 155
     },
     {
       "name": "Amex Offers",

--- a/backend/data/creditcards/capital-one-venture-x.json
+++ b/backend/data/creditcards/capital-one-venture-x.json
@@ -19,6 +19,19 @@
       "value": 100
     },
     {
+      "name": "Uber One membership",
+      "description": "Complimentary Uber One membership (through 11/14/2024) with automatic monthly statement credits.",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 120
+    },
+    {
+      "name": "Lounge visits",
+      "description": "Track the value of Priority Pass™, Plaza Premium, and Capital One Lounge access for you and authorized users.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
       "name": "Cell phone protection",
       "description": "Coverage for damaged or stolen phones when you pay your bill with the card.",
       "frequency": "yearly",

--- a/backend/data/creditcards/chase-ihg-premier.json
+++ b/backend/data/creditcards/chase-ihg-premier.json
@@ -6,10 +6,10 @@
   "benefits": [
     {
       "name": "Free night certificate",
-      "description": "Track the annual free night certificate (up to 40k points).",
+      "description": "Log the redemption value of the annual free night certificate (up to 40k points).",
       "frequency": "yearly",
-      "type": "standard",
-      "value": 200
+      "type": "cumulative",
+      "expected_value": 250
     },
     {
       "name": "IHG statement credits",
@@ -19,8 +19,21 @@
       "value": 100
     },
     {
+      "name": "United TravelBank credit",
+      "description": "$25 in United TravelBank cash deposited twice per year after linking accounts.",
+      "frequency": "semiannual",
+      "type": "incremental",
+      "value": 50
+    },
+    {
       "name": "IHG promotions",
       "description": "Log savings from targeted IHG offers and promotions.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Fourth night free savings",
+      "description": "Track how much you save from the cardholder-only fourth night free award benefit.",
       "frequency": "yearly",
       "type": "cumulative"
     },

--- a/backend/data/creditcards/chase-marriott-boundless.json
+++ b/backend/data/creditcards/chase-marriott-boundless.json
@@ -6,21 +6,26 @@
   "benefits": [
     {
       "name": "Free night certificate",
-      "description": "35,000-point free night certificate each anniversary.",
+      "description": "Log the value of the 35,000-point free night certificate issued each account anniversary.",
       "frequency": "yearly",
-      "type": "standard",
-      "value": 200
+      "type": "cumulative",
+      "expected_value": 250
     },
     {
-      "name": "Marriott statement credits",
-      "description": "Track $25 monthly dining credits from Marriott properties.",
-      "frequency": "monthly",
-      "type": "incremental",
-      "value": 300
+      "name": "Additional free night certificate",
+      "description": "Track redemption value if you earn the extra 35k certificate after $35,000 in spend.",
+      "frequency": "yearly",
+      "type": "cumulative"
     },
     {
       "name": "Marriott offers",
-      "description": "Capture targeted Amex or Chase offers applied to the card.",
+      "description": "Capture targeted Chase or Amex Offers applied to Marriott stays.",
+      "frequency": "yearly",
+      "type": "cumulative"
+    },
+    {
+      "name": "Fifth night free savings",
+      "description": "Record how much you save when redeeming Bonvoy points for 5th night free stays.",
       "frequency": "yearly",
       "type": "cumulative"
     },

--- a/backend/data/creditcards/chase-sapphire-reserve.json
+++ b/backend/data/creditcards/chase-sapphire-reserve.json
@@ -13,17 +13,37 @@
     },
     {
       "name": "DoorDash credits",
-      "description": "$5 monthly DoorDash credits (DoorDash and Caviar orders).",
+      "description": "$5 monthly statement credits toward DoorDash and Caviar orders when you activate DashPass.",
       "frequency": "monthly",
       "type": "incremental",
       "value": 60
     },
     {
+      "name": "DoorDash DashPass membership",
+      "description": "Complimentary DashPass membership for primary and authorized users (currently through 12/31/2024).",
+      "frequency": "yearly",
+      "type": "standard",
+      "value": 96
+    },
+    {
+      "name": "Instacart+ membership & credits",
+      "description": "Instacart+ membership with up to $15 in monthly statement credits (currently through 7/31/2024).",
+      "frequency": "monthly",
+      "type": "incremental",
+      "value": 180
+    },
+    {
       "name": "Lyft Pink membership",
-      "description": "Annual valuation of the included Lyft Pink All Access membership.",
+      "description": "Complimentary Lyft Pink All Access membership (through 12/31/2024) valued annually.",
       "frequency": "yearly",
       "type": "standard",
       "value": 199
+    },
+    {
+      "name": "Lounge visits",
+      "description": "Track the value of Priority Pass™, Sapphire Lounge, and Chase Dining lounge access.",
+      "frequency": "yearly",
+      "type": "cumulative"
     },
     {
       "name": "Chase Offers",

--- a/backend/data/creditcards/chase-southwest-premier-business.json
+++ b/backend/data/creditcards/chase-southwest-premier-business.json
@@ -12,6 +12,13 @@
       "value": 90
     },
     {
+      "name": "Upgraded boarding credits",
+      "description": "Four upgraded boardings per year (when available) to secure an A1-A15 position.",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 160
+    },
+    {
       "name": "Travel credits",
       "description": "Annual statement credits for Wi-Fi and in-flight purchases.",
       "frequency": "yearly",

--- a/backend/data/creditcards/chase-southwest-premier.json
+++ b/backend/data/creditcards/chase-southwest-premier.json
@@ -12,6 +12,13 @@
       "value": 90
     },
     {
+      "name": "EarlyBird Check-In credits",
+      "description": "Two EarlyBird Check-In credits each year to snag automatic check-in.",
+      "frequency": "yearly",
+      "type": "incremental",
+      "value": 60
+    },
+    {
       "name": "In-flight Wi-Fi credits",
       "description": "Track statement credits for Southwest Wi-Fi purchases.",
       "frequency": "yearly",


### PR DESCRIPTION
## Summary
- update the Amex Platinum template with the current roster of annual credits and memberships
- add Uber One access, lounge tracking, and other experiential benefits to Venture X and Sapphire Reserve
- convert hotel free night perks into cumulative benefits and capture new airline/travel credits across IHG, Marriott, and Southwest cards

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d417b10a74832eb21793555a46db5b