### PR TITLE
Fix benefit card layout regressions

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -369,12 +369,13 @@ textarea {
 
 .benefits-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
   gap: 1rem;
   max-height: calc(var(--benefit-card-min-height) * 3 + 2rem);
   overflow-y: auto;
   overflow-x: hidden;
   padding-right: 0.25rem;
+  justify-content: center;
 }
 
 @media (max-width: 900px) {
@@ -403,15 +404,15 @@ textarea {
 
 .benefit-header {
   display: flex;
-  justify-content: space-between;
   align-items: flex-start;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .benefit-name {
   font-size: 1.05rem;
   font-weight: 600;
   color: #0f172a;
+  overflow-wrap: anywhere;
 }
 
 .benefit-frequency {


### PR DESCRIPTION
## Summary
- realign benefit card headers so titles wrap cleanly and action icons stay inside the card
- surface type, frequency, and current window on separate lines and remove outdated potential/tracked copy
- add an incremental progress bar using annual totals and widen the benefits grid for roomier cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d42953b4fc832ebbaef25e53cbb651