### PR TITLE
Align benefit defaults with calendar windows and refresh header layout

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -28,6 +28,15 @@ body {
   backdrop-filter: blur(10px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
   color: #f8fafc;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.header-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
 }
 
 .header-bar {
@@ -35,38 +44,39 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.75rem 1.5rem;
+  min-height: 3.5rem;
 }
 
-.header-brand {
+.header-left {
   display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  max-width: 380px;
-}
-
-.brand-tagline {
-  margin: 0;
-  font-size: 0.82rem;
-  color: rgba(241, 245, 249, 0.78);
-}
-
-.header-nav {
-  display: flex;
-  gap: 0.5rem;
   align-items: center;
+  gap: 0.75rem;
+}
+
+.header-logo {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.nav-toggle {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.35);
 }
 
 .nav-button {
   background: transparent;
   border: none;
   color: #e2e8f0;
-  padding: 0.35rem 0.75rem;
-  border-radius: 6px;
+  padding: 0.6rem 0.9rem;
+  border-radius: 8px;
   cursor: pointer;
-  font-size: 0.92rem;
+  font-size: 0.95rem;
   font-weight: 500;
   transition: background-color 0.2s ease, color 0.2s ease;
+  text-align: left;
+  width: 100%;
 }
 
 .nav-button:hover {
@@ -82,6 +92,56 @@ body {
   display: flex;
   gap: 0.5rem;
   align-items: center;
+  margin-left: auto;
+}
+
+.nav-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.5);
+  backdrop-filter: blur(2px);
+  z-index: 25;
+}
+
+.nav-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: min(80vw, 280px);
+  padding: 4.25rem 1.5rem 2rem;
+  background: rgba(15, 23, 42, 0.92);
+  color: #e2e8f0;
+  box-shadow: 8px 0 24px rgba(15, 23, 42, 0.35);
+  transform: translateX(-100%);
+  transition: transform 0.25s ease;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.nav-drawer.open {
+  transform: translateX(0);
+}
+
+.nav-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.nav-drawer__title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.nav-drawer__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .app-main {
@@ -175,6 +235,17 @@ textarea {
   max-width: 1200px;
 }
 
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1.75rem;
+}
+
+.hero-tagline {
+  max-width: 720px;
+}
+
 .error-message {
   margin-top: 2rem;
   color: #b91c1c;
@@ -198,8 +269,14 @@ textarea {
 
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(540px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(620px, 1fr));
   gap: 1.5rem;
+}
+
+@media (max-width: 680px) {
+  .card-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .admin-table-wrapper {
@@ -288,6 +365,9 @@ textarea {
   flex-direction: column;
   gap: 1.25rem;
   border: 1px solid rgba(148, 163, 184, 0.15);
+  max-width: 760px;
+  width: 100%;
+  margin: 0 auto;
 }
 
 .card-header {
@@ -369,7 +449,7 @@ textarea {
 
 .benefits-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1rem;
   max-height: calc(var(--benefit-card-min-height) * 3 + 2rem);
   overflow-y: auto;
@@ -378,7 +458,7 @@ textarea {
   justify-content: center;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 760px) {
   .benefits-grid {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/frontend/src/utils/dates.js
+++ b/frontend/src/utils/dates.js
@@ -174,3 +174,24 @@ export function computeFrequencyWindows(cycle, frequency) {
   }
   return windows
 }
+
+export function computeCalendarAlignedWindow(frequency, referenceDate = new Date()) {
+  const base = parseDate(referenceDate) || startOfDay(new Date())
+  const year = base.getFullYear()
+  const month = base.getMonth()
+  if (frequency === 'monthly') {
+    const start = makeDate(year, month, 1)
+    return { start, end: addMonths(start, 1) }
+  }
+  if (frequency === 'quarterly') {
+    const quarter = Math.floor(month / 3)
+    const start = makeDate(year, quarter * 3, 1)
+    return { start, end: addMonths(start, 3) }
+  }
+  if (frequency === 'semiannual') {
+    const startMonth = month < 6 ? 0 : 6
+    const start = makeDate(year, startMonth, 1)
+    return { start, end: addMonths(start, 6) }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- align recurring benefit defaults with calendar-based windows while keeping yearly benefits synced to the card year and show benefits ordered by expiration
- prefill the redemption modal with the current window's suggested value
- refresh the header into a compact hamburger-driven layout and widen card/benefit grids so two-column benefit layouts appear on larger screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d42e54c1fc832e991a8e5f27198a24