### PR TITLE
Adjust card grid layout and benefit window labels

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -269,8 +269,9 @@ textarea {
 
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(620px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
   gap: 1.5rem;
+  align-items: stretch;
 }
 
 @media (max-width: 680px) {


### PR DESCRIPTION
## Summary
- update the dashboard card grid to use an auto-fill layout so multiple credit cards can appear per row when space allows
- refine recurring benefit window labels to match calendar and custom range formatting rules for monthly, quarterly, semiannual, and yearly frequencies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4346cf5f0832e826b8058ce3cfc0e