### PR TITLE
Adjust dashboard layout and window labels

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1018,17 +1018,14 @@ onMounted(async () => {
       </nav>
     </aside>
     <main class="app-main">
-      <div class="container">
-        <section class="hero">
-          <h1 class="page-title">CreditWatch</h1>
-          <p class="page-subtitle hero-tagline">
-            Track every card, benefit, and annual fee so you always know if your cards pay for themselves.
-          </p>
-        </section>
+      <section class="hero content-constrained">
+        <p class="page-subtitle hero-tagline">
+          Track every card, benefit, and annual fee so you always know if your cards pay for themselves.
+        </p>
+      </section>
 
       <template v-if="!isAdminView">
-
-        <section class="section-card">
+        <section class="section-card content-constrained">
           <h2 class="section-title">Portfolio overview</h2>
           <div class="summary-row">
             <span>Total annual fees: <strong>${{ totals.annualFees.toFixed(2) }}</strong></span>
@@ -1038,13 +1035,15 @@ onMounted(async () => {
           </div>
         </section>
 
-        <section>
-          <h2 class="section-title">Your cards</h2>
-          <p v-if="loading" class="empty-state">Loading your cards...</p>
-          <p v-else-if="!cards.length" class="empty-state">
-            No cards yet. Add your first credit card to begin tracking benefits.
-          </p>
-          <div v-else>
+        <section class="cards-section">
+          <div class="content-constrained">
+            <h2 class="section-title">Your cards</h2>
+            <p v-if="loading" class="empty-state">Loading your cards...</p>
+            <p v-else-if="!cards.length" class="empty-state">
+              No cards yet. Add your first credit card to begin tracking benefits.
+            </p>
+          </div>
+          <div v-if="!loading && cards.length" class="cards-grid-wrapper">
             <CreditCardList
               :cards="cards"
               :frequencies="frequencies"
@@ -1064,7 +1063,7 @@ onMounted(async () => {
       </template>
 
       <template v-else>
-        <section class="section-card admin-board">
+        <section class="section-card admin-board content-constrained">
           <div class="section-header">
             <div>
               <h2 class="section-title">Preconfigured cards</h2>
@@ -1136,11 +1135,12 @@ onMounted(async () => {
         </section>
       </template>
 
-      <p v-if="error" class="empty-state error-message">
-        {{ error }}
-      </p>
-    </div>
-  </main>
+      <div v-if="error" class="content-constrained">
+        <p class="empty-state error-message">
+          {{ error }}
+        </p>
+      </div>
+    </main>
   </div>
 
   <BaseModal :open="showCardModal" title="Add a credit card" @close="closeCardModal">

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -5,6 +5,7 @@
   color: #0f172a;
   background-color: #f1f5f9;
   --benefit-card-min-height: 220px;
+  --page-padding: clamp(1rem, 4vw, 3rem);
 }
 
 * {
@@ -34,9 +35,8 @@ body {
 }
 
 .header-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 1.5rem;
+  width: 100%;
+  padding: 0 var(--page-padding);
 }
 
 .header-bar {
@@ -146,6 +146,7 @@ body {
 
 .app-main {
   flex: 1;
+  padding: 2rem var(--page-padding) 4rem;
 }
 
 a {
@@ -229,10 +230,10 @@ textarea {
   font: inherit;
 }
 
-.container {
+.content-constrained {
   margin: 0 auto;
-  padding: 2rem 1.5rem 4rem;
   max-width: 1200px;
+  width: 100%;
 }
 
 .hero {
@@ -255,21 +256,23 @@ textarea {
   background: rgba(254, 242, 242, 0.65);
 }
 
-.page-title {
-  font-size: clamp(1.75rem, 2.5vw + 0.8rem, 2.5rem);
-  font-weight: 700;
-  margin-bottom: 0.15rem;
-  color: #0f172a;
-}
-
 .page-subtitle {
   color: #475569;
   margin-bottom: 2rem;
 }
 
+.cards-section {
+  margin-top: 2rem;
+}
+
+.cards-grid-wrapper {
+  margin: 1.5rem auto 0;
+  width: 100%;
+}
+
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(600px, 1fr));
   gap: 1.5rem;
   align-items: stretch;
 }

--- a/frontend/src/utils/dates.js
+++ b/frontend/src/utils/dates.js
@@ -164,10 +164,15 @@ export function computeFrequencyWindows(cycle, frequency) {
   let index = 1
   while (cursor < cycle.end) {
     const windowEnd = addMonths(cursor, monthsPerWindow)
+    const clampedEnd = windowEnd < cycle.end ? windowEnd : cycle.end
+    const label =
+      frequency === 'monthly'
+        ? new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' }).format(cursor)
+        : `${frequency === 'quarterly' ? 'Quarter' : 'Half'} ${index} · ${formatRangeLabel(cursor, clampedEnd)}`
     windows.push({
       start: cursor,
-      end: windowEnd < cycle.end ? windowEnd : cycle.end,
-      label: `${frequency === 'monthly' ? 'Month' : frequency === 'quarterly' ? 'Quarter' : 'Half'} ${index} · ${formatRangeLabel(cursor, windowEnd < cycle.end ? windowEnd : cycle.end)}`
+      end: clampedEnd,
+      label
     })
     cursor = windowEnd
     index += 1


### PR DESCRIPTION
## Summary
- remove the dashboard hero title and restructure the main layout so hero, portfolio, and admin sections stay constrained while the card grid spans the page margins.
- update shared styling to use a global page padding, expand the credit card grid to 600px columns, and expose a `content-constrained` helper for consistent margins.
- render full month names for monthly frequency windows to improve the default labels.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d43a5ffcf0832e98dbc64feabe3177