### PR TITLE
Support configurable backend URL via env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,13 @@ services:
   frontend:
     build:
       context: ./frontend
+      args:
+        VITE_BACKEND_URL: http://backend
+        VITE_BACKEND_PORT: "8000"
     depends_on:
       - backend
+    environment:
+      - VITE_BACKEND_URL=http://backend
+      - VITE_BACKEND_PORT=8000
     ports:
       - "5173:80"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,10 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
+ARG VITE_BACKEND_URL=http://backend
+ARG VITE_BACKEND_PORT=8000
+ENV VITE_BACKEND_URL=${VITE_BACKEND_URL}
+ENV VITE_BACKEND_PORT=${VITE_BACKEND_PORT}
 RUN npm run build
 
 FROM nginx:1.27-alpine

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, onMounted, reactive, ref, watch } from 'vue'
-import axios from 'axios'
+import apiClient from './utils/apiClient'
 import BaseModal from './components/BaseModal.vue'
 import BenefitCard from './components/BenefitCard.vue'
 import CreditCardList from './components/CreditCardList.vue'
@@ -282,7 +282,7 @@ const benefitsCollection = computed(() => {
 
 async function loadFrequencies() {
   try {
-    const response = await axios.get('/api/frequencies')
+    const response = await apiClient.get('/api/frequencies')
     if (Array.isArray(response.data) && response.data.length) {
       frequencies.value = response.data
     }
@@ -295,7 +295,7 @@ async function loadCards() {
   loading.value = true
   error.value = ''
   try {
-    const response = await axios.get('/api/cards')
+    const response = await apiClient.get('/api/cards')
     cards.value = response.data
   } catch (err) {
     error.value = 'Unable to load cards. Ensure the backend is running.'
@@ -306,7 +306,7 @@ async function loadCards() {
 
 async function loadPreconfiguredCards() {
   try {
-    const response = await axios.get('/api/preconfigured/cards')
+    const response = await apiClient.get('/api/preconfigured/cards')
     if (Array.isArray(response.data)) {
       preconfiguredCards.value = response.data
     }
@@ -539,12 +539,12 @@ async function submitAdminCard() {
       })
     }
     if (adminModal.mode === 'edit') {
-      await axios.put(
+      await apiClient.put(
         `/api/admin/preconfigured/cards/${encodeURIComponent(adminModal.originalSlug)}`,
         payload
       )
     } else {
-      await axios.post('/api/admin/preconfigured/cards', payload)
+      await apiClient.post('/api/admin/preconfigured/cards', payload)
     }
     await loadPreconfiguredCards()
     closeAdminModal()
@@ -558,7 +558,7 @@ async function submitAdminCard() {
 
 async function handleDeletePreconfiguredCard(slug) {
   try {
-    await axios.delete(`/api/admin/preconfigured/cards/${encodeURIComponent(slug)}`)
+    await apiClient.delete(`/api/admin/preconfigured/cards/${encodeURIComponent(slug)}`)
     await loadPreconfiguredCards()
   } catch (err) {
     error.value = 'Unable to delete the preconfigured card.'
@@ -585,7 +585,7 @@ async function handleCreateCard() {
       fee_due_date: newCard.fee_due_date,
       year_tracking_mode: newCard.year_tracking_mode
     }
-    const response = await axios.post('/api/cards', payload)
+    const response = await apiClient.post('/api/cards', payload)
     const template = selectedTemplate.value
     if (template) {
       for (const benefit of template.benefits) {
@@ -613,7 +613,7 @@ async function handleCreateCard() {
         if (benefitPayload.value === undefined) {
           delete benefitPayload.value
         }
-        await axios.post(`/api/cards/${response.data.id}/benefits`, benefitPayload)
+        await apiClient.post(`/api/cards/${response.data.id}/benefits`, benefitPayload)
       }
       await loadCards()
     } else {
@@ -632,8 +632,8 @@ async function handleAddBenefit({ cardId, payload }) {
     if (body.value === undefined) {
       delete body.value
     }
-    await axios.post(`/api/cards/${cardId}/benefits`, body)
-    const refreshed = await axios.get('/api/cards')
+    await apiClient.post(`/api/cards/${cardId}/benefits`, body)
+    const refreshed = await apiClient.get('/api/cards')
     cards.value = refreshed.data
     await refreshOpenModals()
   } catch (err) {
@@ -643,8 +643,8 @@ async function handleAddBenefit({ cardId, payload }) {
 
 async function handleToggleBenefit({ id, value }) {
   try {
-    await axios.post(`/api/benefits/${id}/usage`, { is_used: value })
-    const refreshed = await axios.get('/api/cards')
+    await apiClient.post(`/api/benefits/${id}/usage`, { is_used: value })
+    const refreshed = await apiClient.get('/api/cards')
     cards.value = refreshed.data
     await refreshOpenModals()
   } catch (err) {
@@ -654,8 +654,8 @@ async function handleToggleBenefit({ id, value }) {
 
 async function handleDeleteBenefit(benefitId) {
   try {
-    await axios.delete(`/api/benefits/${benefitId}`)
-    const refreshed = await axios.get('/api/cards')
+    await apiClient.delete(`/api/benefits/${benefitId}`)
+    const refreshed = await apiClient.get('/api/cards')
     cards.value = refreshed.data
     await refreshOpenModals()
   } catch (err) {
@@ -665,7 +665,7 @@ async function handleDeleteBenefit(benefitId) {
 
 async function handleDeleteCard(cardId) {
   try {
-    await axios.delete(`/api/cards/${cardId}`)
+    await apiClient.delete(`/api/cards/${cardId}`)
     await loadCards()
     await refreshOpenModals()
   } catch (err) {
@@ -736,9 +736,9 @@ async function submitRedemption() {
       occurred_on: redemptionModal.occurred_on
     }
     if (redemptionModal.mode === 'edit' && redemptionModal.redemptionId) {
-      await axios.put(`/api/redemptions/${redemptionModal.redemptionId}`, body)
+      await apiClient.put(`/api/redemptions/${redemptionModal.redemptionId}`, body)
     } else {
-      await axios.post(`/api/benefits/${redemptionModal.benefitId}/redemptions`, body)
+      await apiClient.post(`/api/benefits/${redemptionModal.benefitId}/redemptions`, body)
     }
     await loadCards()
     await refreshOpenModals()
@@ -771,7 +771,7 @@ function handleEditRedemption(entry) {
 
 async function handleDeleteRedemption(entry) {
   try {
-    await axios.delete(`/api/redemptions/${entry.id}`)
+    await apiClient.delete(`/api/redemptions/${entry.id}`)
     await loadCards()
     await refreshOpenModals()
   } catch (err) {
@@ -807,7 +807,7 @@ async function handleUpdateBenefit({ cardId, benefitId, payload }) {
     if (body.value === undefined) {
       delete body.value
     }
-    await axios.put(`/api/benefits/${benefitId}`, body)
+    await apiClient.put(`/api/benefits/${benefitId}`, body)
     await loadCards()
     await refreshOpenModals()
   } catch (err) {
@@ -853,7 +853,7 @@ async function submitEditCard() {
       fee_due_date: editCardModal.form.fee_due_date,
       year_tracking_mode: editCardModal.form.year_tracking_mode
     }
-    await axios.put(`/api/cards/${editCardModal.cardId}`, payload)
+    await apiClient.put(`/api/cards/${editCardModal.cardId}`, payload)
     await loadCards()
     await refreshOpenModals()
     closeEditCardModal()
@@ -932,7 +932,7 @@ function formatCycleRange(start, end) {
 }
 
 async function fetchBenefitRedemptions(benefitId) {
-  const response = await axios.get(`/api/benefits/${benefitId}/redemptions`)
+  const response = await apiClient.get(`/api/benefits/${benefitId}/redemptions`)
   return Array.isArray(response.data) ? response.data : []
 }
 

--- a/frontend/src/utils/apiClient.js
+++ b/frontend/src/utils/apiClient.js
@@ -1,0 +1,40 @@
+import axios from 'axios'
+
+function resolveBackendBaseURL() {
+  const rawUrl = import.meta.env.VITE_BACKEND_URL
+  const rawPort = import.meta.env.VITE_BACKEND_PORT
+
+  if (!rawUrl) {
+    return ''
+  }
+
+  let normalized = String(rawUrl).trim()
+  if (!normalized) {
+    return ''
+  }
+
+  if (!/^https?:\/\//i.test(normalized)) {
+    normalized = `http://${normalized}`
+  }
+
+  try {
+    const url = new URL(normalized)
+    if (rawPort) {
+      url.port = String(rawPort)
+    }
+    return url.origin
+  } catch (error) {
+    console.warn(
+      'Invalid VITE_BACKEND_URL provided. Falling back to same-origin API requests.'
+    )
+    return ''
+  }
+}
+
+const baseURL = resolveBackendBaseURL()
+
+const apiClient = axios.create({
+  baseURL: baseURL || undefined
+})
+
+export default apiClient

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,15 +1,44 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
-export default defineConfig({
-  plugins: [vue()],
-  server: {
-    host: '0.0.0.0',
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://backend:8000',
-        changeOrigin: true
+function resolveBackendProxyTarget(env) {
+  const rawUrl = env.VITE_BACKEND_URL || 'http://backend'
+  const rawPort = env.VITE_BACKEND_PORT || '8000'
+
+  let normalized = String(rawUrl).trim()
+  if (!/^https?:\/\//i.test(normalized)) {
+    normalized = `http://${normalized}`
+  }
+
+  try {
+    const url = new URL(normalized)
+    if (rawPort) {
+      url.port = String(rawPort)
+    }
+    return url.origin
+  } catch (error) {
+    console.warn(
+      'Invalid VITE_BACKEND_URL for Vite proxy target. Falling back to http://backend:8000.'
+    )
+    return 'http://backend:8000'
+  }
+}
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const target = resolveBackendProxyTarget(env)
+  const devPort = Number(env.VITE_DEV_SERVER_PORT || 5173)
+
+  return {
+    plugins: [vue()],
+    server: {
+      host: '0.0.0.0',
+      port: Number.isNaN(devPort) ? 5173 : devPort,
+      proxy: {
+        '/api': {
+          target,
+          changeOrigin: true
+        }
       }
     }
   }

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 PROJECT_DIR=$(cd "$(dirname "$0")" && pwd)
 VENV_PATH="$PROJECT_DIR/.venv"
+FRONTEND_ENV="$PROJECT_DIR/frontend/.env.local"
 
 if [ ! -d "$VENV_PATH" ]; then
   python3 -m venv "$VENV_PATH"
@@ -16,6 +17,25 @@ pip install -r "$PROJECT_DIR/backend/requirements.txt"
 
 pushd "$PROJECT_DIR/frontend" >/dev/null
 npm install
+python3 - "$FRONTEND_ENV" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+desired = {
+    "VITE_BACKEND_URL": "http://127.0.0.1",
+    "VITE_BACKEND_PORT": "8000",
+}
+existing = {}
+if path.exists():
+    for line in path.read_text().splitlines():
+        if "=" in line and not line.lstrip().startswith("#"):
+            key, value = line.split("=", 1)
+            existing[key.strip()] = value.strip()
+existing.update(desired)
+content = "\n".join(f"{key}={value}" for key, value in existing.items()) + "\n"
+path.write_text(content)
+PY
 popd >/dev/null
 
 echo "Environment is ready. Starting the FastAPI server..."


### PR DESCRIPTION
## Summary
- create a dedicated Axios client that respects `VITE_BACKEND_URL` and `VITE_BACKEND_PORT`
- load backend host/port from environment in the Vite dev server and Docker build
- ensure local setup and docker-compose seed the appropriate frontend env values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4a0d8c1f0832e9ac546f5060a8206