### PR TITLE
Allow storing five digit card suffixes

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -42,7 +42,11 @@ class CreditCard(SQLModel, table=True):
         index=True,
         description="Card issuer or bank name",
     )
-    last_four: str = Field(min_length=4, max_length=4, description="Last four digits")
+    last_four: str = Field(
+        min_length=4,
+        max_length=5,
+        description="Last four or five digits",
+    )
     account_name: str = Field(index=True, description="Account holder or user account identifier")
     annual_fee: float = Field(ge=0)
     fee_due_date: date

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -150,7 +150,7 @@ class BenefitRedemptionUpdate(SQLModel):
 class CreditCardBase(SQLModel):
     card_name: str
     company_name: str
-    last_four: str = Field(min_length=4, max_length=4)
+    last_four: str = Field(min_length=4, max_length=5)
     account_name: str
     annual_fee: float = Field(ge=0)
     fee_due_date: date
@@ -164,7 +164,7 @@ class CreditCardCreate(CreditCardBase):
 class CreditCardUpdate(SQLModel):
     card_name: Optional[str] = None
     company_name: Optional[str] = None
-    last_four: Optional[str] = Field(default=None, min_length=4, max_length=4)
+    last_four: Optional[str] = Field(default=None, min_length=4, max_length=5)
     account_name: Optional[str] = None
     annual_fee: Optional[float] = Field(default=None, ge=0)
     fee_due_date: Optional[date] = None

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -863,15 +863,20 @@ function closeCardModal() {
 }
 
 async function handleCreateCard() {
-  if (!newCard.card_name || !newCard.company_name || newCard.last_four.length !== 4) {
-    error.value = 'Please provide a card name, company, and the last four digits.'
+  const trimmedLastDigits = newCard.last_four.trim()
+  if (
+    !newCard.card_name ||
+    !newCard.company_name ||
+    !/^\d{4,5}$/.test(trimmedLastDigits)
+  ) {
+    error.value = 'Please provide a card name, company, and the last four or five digits.'
     return
   }
   try {
     const payload = {
       card_name: newCard.card_name,
       company_name: newCard.company_name,
-      last_four: newCard.last_four,
+      last_four: trimmedLastDigits,
       account_name: newCard.account_name,
       annual_fee: Number(newCard.annual_fee || 0),
       fee_due_date: newCard.fee_due_date,
@@ -912,6 +917,7 @@ async function handleCreateCard() {
     } else {
       cards.value.push(createdCard)
     }
+    newCard.last_four = trimmedLastDigits
     closeCardModal()
     error.value = ''
   } catch (err) {
@@ -1136,11 +1142,16 @@ async function submitEditCard() {
   if (!editCardModal.cardId) {
     return
   }
+  const trimmedLastDigits = editCardModal.form.last_four.trim()
+  if (!/^\d{4,5}$/.test(trimmedLastDigits)) {
+    error.value = 'Please provide the last four or five digits.'
+    return
+  }
   try {
     const payload = {
       card_name: editCardModal.form.card_name,
       company_name: editCardModal.form.company_name,
-      last_four: editCardModal.form.last_four,
+      last_four: trimmedLastDigits,
       account_name: editCardModal.form.account_name,
       annual_fee: Number(editCardModal.form.annual_fee || 0),
       fee_due_date: editCardModal.form.fee_due_date,
@@ -1905,9 +1916,10 @@ onMounted(async () => {
         <input
           v-model="newCard.last_four"
           type="text"
-          maxlength="4"
+          inputmode="numeric"
+          maxlength="5"
           minlength="4"
-          placeholder="Last four digits"
+          placeholder="Last four or five digits"
           required
         />
         <input v-model="newCard.account_name" type="text" placeholder="Account name" required />
@@ -1948,9 +1960,10 @@ onMounted(async () => {
         <input
           v-model="editCardModal.form.last_four"
           type="text"
-          maxlength="4"
+          inputmode="numeric"
+          maxlength="5"
           minlength="4"
-          placeholder="Last four digits"
+          placeholder="Last four or five digits"
           required
         />
         <input v-model="editCardModal.form.account_name" type="text" placeholder="Account name" required />


### PR DESCRIPTION
## Summary
- allow credit cards to store a four or five digit suffix in the backend models and schemas
- update the create and edit card flows to accept, validate, and describe a 4-5 digit suffix in the UI

## Testing
- npm run build
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d539406f50832eb4c9fe547500b353