### PR TITLE
Add automated Google Drive backups and import tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ CreditWatch is a local-first dashboard for tracking credit cards, their annual f
 - ✅ Mark benefits as used to keep a running tally of realized value versus your annual fees.
 - 📊 Gorgeous, card-based Vue 3 interface with at-a-glance progress bars for each credit card.
 - 🗂️ SQLite persistence so your data lives alongside the app when run locally or inside Docker.
+- ☁️ Automated Google Drive backups with monthly retention and one-click restore from the admin panel.
 
 ## Project layout
 
@@ -75,6 +76,17 @@ FastAPI automatically exposes interactive docs at [http://localhost:8010/docs](h
 2. Select a card and add benefits such as travel credits or dining offers, including their value and reset cadence.
 3. When you use a benefit, hit **Mark used**—the dashboard will adjust the utilized total and net position.
 4. Review the progress bars to see which cards are paying for themselves and which still need attention.
+
+### Google Drive backups
+
+The **Admin → Database backups** panel lets you automatically copy the SQLite database to Google Drive and restore it later.
+
+1. Create a Google Cloud service account with Drive API access and grant it access to the folder that should store backups.
+2. Paste the folder ID and the JSON credentials into the backup form, then save the configuration.
+3. CreditWatch will schedule a backup for one hour after the most recent data change. Each month is stored as a single
+   `creditwatch-backup-YYYY-MM.db` file—new backups overwrite the current month while preserving previous months.
+4. Use **Run backup now** for an immediate snapshot or upload a `.db` archive to replace the live database. The app
+   automatically reloads data and schedules a fresh backup after an import.
 
 ## Development tips
 

--- a/backend/app/backups.py
+++ b/backend/app/backups.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from sqlmodel import Session
+
+from . import crud
+from .database import DATABASE_PATH
+from .google_drive import GoogleDriveBackupClient
+
+logger = logging.getLogger("creditwatch.backups")
+
+
+@dataclass
+class BackupResult:
+    """Structured result of a backup execution."""
+
+    success: bool
+    message: str
+    timestamp: datetime
+    file_id: Optional[str] = None
+    file_name: Optional[str] = None
+    size_bytes: Optional[int] = None
+
+
+class BackupService:
+    """Coordinate delayed database backups with Google Drive."""
+
+    def __init__(self, *, engine, delay: timedelta | None = None) -> None:
+        self._engine = engine
+        self._delay = delay or timedelta(hours=1)
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._scheduled_task: asyncio.Task[None] | None = None
+        self._lock = asyncio.Lock()
+        self._configured = False
+        self._next_run_at: datetime | None = None
+        self._last_result: BackupResult | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle management
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Capture the running event loop for future scheduling."""
+
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:  # pragma: no cover - defensive guard
+            self._loop = asyncio.get_event_loop()
+        logger.debug("Backup service initialised")
+
+    async def stop(self) -> None:
+        """Cancel any pending backup tasks and wait for them to exit."""
+
+        if self._scheduled_task is None:
+            return
+        self._scheduled_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._scheduled_task
+        self._scheduled_task = None
+        self._next_run_at = None
+
+    # ------------------------------------------------------------------
+    # Configuration helpers
+    # ------------------------------------------------------------------
+    def refresh_configuration(self) -> None:
+        """Load configuration state from the database."""
+
+        with Session(self._engine) as session:
+            settings = crud.get_backup_settings(session)
+        self._configured = bool(settings and settings.is_configured)
+        logger.debug("Backup service configuration updated: %s", self._configured)
+
+    def apply_settings_change(self, configured: bool) -> None:
+        """Update the in-memory configuration flag."""
+
+        self._configured = configured
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def notify_change(self) -> None:
+        """Schedule a backup after the configured delay."""
+
+        if not self._configured:
+            logger.debug("Backup configuration incomplete; skipping schedule request")
+            return
+        if self._loop is None:
+            logger.debug("Backup service loop not ready; change ignored")
+            return
+        self._loop.call_soon_threadsafe(self._schedule_backup)
+
+    async def run_immediately(self) -> BackupResult:
+        """Execute a backup immediately."""
+
+        if not self._configured:
+            now = datetime.utcnow()
+            result = BackupResult(
+                success=False,
+                message="Backup configuration is incomplete.",
+                timestamp=now,
+            )
+            self._last_result = result
+            return result
+        await self._cancel_pending()
+        return await self._perform_backup()
+
+    def get_status(self) -> dict[str, Optional[datetime]]:
+        """Return transient runtime information for API responses."""
+
+        return {
+            "next_run_at": self._next_run_at,
+            "last_result": self._last_result,
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers executed on the event loop
+    # ------------------------------------------------------------------
+    def _schedule_backup(self) -> None:
+        if self._scheduled_task is not None:
+            self._scheduled_task.cancel()
+        delay_seconds = max(self._delay.total_seconds(), 0)
+        self._next_run_at = datetime.utcnow() + timedelta(seconds=delay_seconds)
+        self._scheduled_task = asyncio.create_task(self._delayed_backup(delay_seconds))
+        logger.debug(
+            "Scheduled next database backup for %s", self._next_run_at.isoformat()
+        )
+
+    async def _delayed_backup(self, delay_seconds: float) -> None:
+        try:
+            await asyncio.sleep(delay_seconds)
+            await self._perform_backup()
+        except asyncio.CancelledError:
+            logger.debug("Backup timer cancelled")
+            raise
+        except Exception:  # pragma: no cover - defensive guard
+            logger.exception("Unhandled exception while running scheduled backup")
+        finally:
+            self._scheduled_task = None
+            self._next_run_at = None
+
+    async def _cancel_pending(self) -> None:
+        if self._scheduled_task is None:
+            return
+        self._scheduled_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._scheduled_task
+        self._scheduled_task = None
+        self._next_run_at = None
+
+    async def _perform_backup(self) -> BackupResult:
+        async with self._lock:
+            try:
+                result = await asyncio.to_thread(self._execute_backup)
+            except Exception as exc:  # pragma: no cover - defensive guard
+                logger.exception("Database backup failed")
+                result = BackupResult(
+                    success=False,
+                    message=str(exc),
+                    timestamp=datetime.utcnow(),
+                )
+            self._last_result = result
+            return result
+
+    # ------------------------------------------------------------------
+    # Blocking backup implementation executed in a worker thread
+    # ------------------------------------------------------------------
+    def _execute_backup(self) -> BackupResult:
+        database_path = Path(DATABASE_PATH) / "creditwatch.db"
+        now = datetime.utcnow()
+        if not database_path.exists():
+            message = f"Database file not found at {database_path}".rstrip()
+            logger.warning(message)
+            return BackupResult(success=False, message=message, timestamp=now)
+
+        with Session(self._engine) as session:
+            settings = crud.get_backup_settings(session)
+            if settings is None or not settings.is_configured:
+                message = "Backup configuration is incomplete."
+                logger.warning(message)
+                return BackupResult(success=False, message=message, timestamp=now)
+
+            client = GoogleDriveBackupClient.from_serialised_credentials(
+                folder_id=settings.drive_folder_id,
+                service_account_json=settings.service_account_json,
+            )
+
+            file_name = f"creditwatch-backup-{now:%Y-%m}.db"
+            drive_result = client.upload_backup(source=database_path, target_name=file_name)
+
+            settings.last_backup_at = now
+            settings.last_backup_file_id = drive_result.file_id
+            settings.last_backup_filename = drive_result.file_name
+            settings.last_backup_size = drive_result.size_bytes
+            settings.last_backup_error = None
+            settings.updated_at = now
+
+            crud.save_backup_settings(session, settings)
+
+        return BackupResult(
+            success=True,
+            message="Backup uploaded successfully.",
+            timestamp=now,
+            file_id=drive_result.file_id,
+            file_name=drive_result.file_name,
+            size_bytes=drive_result.size_bytes,
+        )

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -6,7 +6,9 @@ from typing import Dict, List, Optional, Sequence, Tuple
 from sqlalchemy import func
 from sqlmodel import Session, select
 
+from .google_drive import extract_service_account_email
 from .models import (
+    BackupSettings,
     Benefit,
     BenefitFrequency,
     BenefitRedemption,
@@ -15,6 +17,8 @@ from .models import (
     NotificationSettings,
 )
 from .schemas import (
+    BackupSettingsUpdate,
+    BackupSettingsWrite,
     BenefitCreate,
     BenefitRedemptionCreate,
     BenefitRedemptionUpdate,
@@ -210,6 +214,52 @@ def upsert_notification_settings(
         for key, value in data.items():
             setattr(settings, key, value)
     settings.updated_at = now
+    session.add(settings)
+    session.commit()
+    session.refresh(settings)
+    return settings
+
+
+def get_backup_settings(session: Session) -> BackupSettings | None:
+    statement = select(BackupSettings).limit(1)
+    return session.exec(statement).first()
+
+
+def upsert_backup_settings(
+    session: Session, payload: BackupSettingsWrite | BackupSettingsUpdate
+) -> BackupSettings:
+    data = payload.model_dump(exclude_unset=True)
+    settings = get_backup_settings(session)
+    now = datetime.utcnow()
+
+    if settings is None:
+        if not isinstance(payload, BackupSettingsWrite):
+            raise ValueError("Backup settings have not been configured yet.")
+        email = extract_service_account_email(data["service_account_json"])
+        settings = BackupSettings(
+            drive_folder_id=data["drive_folder_id"],
+            service_account_json=data["service_account_json"],
+            service_account_email=email,
+            created_at=now,
+            updated_at=now,
+        )
+    else:
+        if "drive_folder_id" in data:
+            settings.drive_folder_id = data["drive_folder_id"]
+        if "service_account_json" in data:
+            settings.service_account_json = data["service_account_json"]
+            settings.service_account_email = extract_service_account_email(
+                settings.service_account_json
+            )
+        settings.updated_at = now
+
+    session.add(settings)
+    session.commit()
+    session.refresh(settings)
+    return settings
+
+
+def save_backup_settings(session: Session, settings: BackupSettings) -> BackupSettings:
     session.add(settings)
     session.commit()
     session.refresh(settings)

--- a/backend/app/google_drive.py
+++ b/backend/app/google_drive.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaFileUpload
+
+logger = logging.getLogger("creditwatch.backups.google_drive")
+
+SCOPES = ["https://www.googleapis.com/auth/drive.file"]
+
+
+@dataclass
+class GoogleDriveBackupResult:
+    """Result payload returned after uploading a backup."""
+
+    file_id: str
+    file_name: str
+    size_bytes: int
+
+
+class GoogleDriveBackupClient:
+    """Thin wrapper for interacting with the Google Drive API."""
+
+    def __init__(self, *, folder_id: str, service_account_info: dict) -> None:
+        if not folder_id:
+            raise ValueError("A Google Drive folder ID is required.")
+        if not service_account_info:
+            raise ValueError("Service account credentials are required.")
+        credentials = service_account.Credentials.from_service_account_info(
+            service_account_info, scopes=SCOPES
+        )
+        self._folder_id = folder_id
+        self._service = build(
+            "drive",
+            "v3",
+            credentials=credentials,
+            cache_discovery=False,
+        )
+
+    @classmethod
+    def from_serialised_credentials(
+        cls, *, folder_id: str, service_account_json: str
+    ) -> "GoogleDriveBackupClient":
+        try:
+            data = json.loads(service_account_json)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+            raise ValueError("Invalid Google service account JSON provided.") from exc
+        return cls(folder_id=folder_id, service_account_info=data)
+
+    def upload_backup(self, *, source: Path, target_name: str) -> GoogleDriveBackupResult:
+        """Upload the provided SQLite database to Drive.
+
+        If a file with ``target_name`` already exists in the configured folder it will
+        be replaced, otherwise a new file will be created.
+        """
+
+        if not source.exists():
+            raise FileNotFoundError(f"Backup source file not found: {source}")
+
+        media = MediaFileUpload(
+            str(source), mimetype="application/x-sqlite3", resumable=False
+        )
+        query = (
+            f"name = '{target_name}' and '{self._folder_id}' in parents and trashed = false"
+        )
+        existing_file_id: Optional[str] = None
+        try:
+            response = (
+                self._service.files()
+                .list(
+                    q=query,
+                    spaces="drive",
+                    fields="files(id, name)",
+                    pageSize=1,
+                )
+                .execute()
+            )
+        except HttpError:  # pragma: no cover - network failure guard
+            logger.exception("Failed to query existing Google Drive backups")
+            raise
+        files = response.get("files", [])
+        if files:
+            existing_file_id = files[0].get("id")
+
+        try:
+            if existing_file_id:
+                file_metadata = {"name": target_name}
+                update_request = self._service.files().update(
+                    fileId=existing_file_id,
+                    media_body=media,
+                    body=file_metadata,
+                )
+                result = update_request.execute()
+                file_id = result["id"]
+            else:
+                file_metadata = {
+                    "name": target_name,
+                    "parents": [self._folder_id],
+                }
+                create_request = self._service.files().create(
+                    body=file_metadata,
+                    media_body=media,
+                    fields="id, name",
+                )
+                result = create_request.execute()
+                file_id = result["id"]
+        except HttpError:
+            logger.exception("Failed to upload Google Drive backup")
+            raise
+
+        size_bytes = source.stat().st_size
+        return GoogleDriveBackupResult(
+            file_id=file_id,
+            file_name=target_name,
+            size_bytes=size_bytes,
+        )
+
+
+def extract_service_account_email(service_account_json: str) -> Optional[str]:
+    """Attempt to read the service account's email from the JSON payload."""
+
+    try:
+        payload = json.loads(service_account_json)
+    except json.JSONDecodeError:
+        return None
+    email = payload.get("client_email")
+    if not isinstance(email, str):
+        return None
+    return email

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
 import calendar
+import shutil
 from datetime import date, timedelta
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+from uuid import uuid4
 
-from fastapi import Depends, FastAPI, HTTPException, Response, status
+from fastapi import Depends, FastAPI, File, HTTPException, Response, UploadFile, status
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import Session
 
 from . import crud
-from .database import engine, get_session, init_db
+from .backups import BackupService
+from .database import DATABASE_PATH, engine, get_session, init_db
 from .models import (
+    BackupSettings,
     Benefit,
     BenefitFrequency,
     BenefitRedemption,
@@ -29,6 +34,9 @@ from .schemas import (
     CreditCardCreate,
     CreditCardUpdate,
     CreditCardWithBenefits,
+    BackupSettingsRead,
+    BackupSettingsUpdate,
+    BackupSettingsWrite,
     NotificationCustomMessage,
     NotificationDailyTestRequest,
     NotificationDispatchResult,
@@ -57,16 +65,68 @@ app.add_middleware(
 )
 
 
+DATABASE_FILE = Path(DATABASE_PATH) / "creditwatch.db"
+
+
+def _get_backup_service(optional: bool = False) -> BackupService | None:
+    service: BackupService | None = getattr(app.state, "backup_service", None)
+    if service is None and not optional:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Backup service is not ready.",
+        )
+    return service
+
+
+def schedule_backup_after_change() -> None:
+    service = _get_backup_service(optional=True)
+    if service is not None:
+        service.notify_change()
+
+
+def build_backup_settings_response(settings: BackupSettings | None) -> BackupSettingsRead:
+    service = _get_backup_service(optional=True)
+    status_info = service.get_status() if service is not None else {}
+    last_result = status_info.get("last_result") if status_info else None
+    payload = {
+        "drive_folder_id": settings.drive_folder_id if settings else None,
+        "service_account_email": settings.service_account_email if settings else None,
+        "is_configured": bool(settings.is_configured) if settings else False,
+        "last_backup_at": settings.last_backup_at if settings else None,
+        "last_backup_filename": settings.last_backup_filename if settings else None,
+        "last_backup_size": settings.last_backup_size if settings else None,
+        "last_backup_error": settings.last_backup_error if settings else None,
+        "next_backup_at": status_info.get("next_run_at"),
+        "last_result_at": last_result.timestamp if last_result else None,
+        "last_result_message": last_result.message if last_result else None,
+        "last_result_success": last_result.success if last_result else None,
+    }
+    return BackupSettingsRead(**payload)
+
+
+def require_backup_service() -> BackupService:
+    service = _get_backup_service(optional=False)
+    assert service is not None
+    return service
+
+
 @app.on_event("startup")
 async def on_startup() -> None:
     init_db()
-    service = NotificationService(engine=engine)
-    service.start()
-    app.state.notification_service = service
+    notification_service = NotificationService(engine=engine)
+    notification_service.start()
+    app.state.notification_service = notification_service
+    backup_service = BackupService(engine=engine)
+    backup_service.start()
+    backup_service.refresh_configuration()
+    app.state.backup_service = backup_service
 
 
 @app.on_event("shutdown")
 async def on_shutdown() -> None:
+    backup_service: BackupService | None = getattr(app.state, "backup_service", None)
+    if backup_service is not None:
+        await backup_service.stop()
     service: NotificationService | None = getattr(app.state, "notification_service", None)
     if service is not None:
         await service.stop()
@@ -160,6 +220,7 @@ def put_notification_settings(
     payload: NotificationSettingsWrite, session: Session = Depends(get_session)
 ) -> NotificationSettingsRead:
     settings = crud.upsert_notification_settings(session, payload)
+    schedule_backup_after_change()
     return NotificationSettingsRead.model_validate(settings, from_attributes=True)
 
 
@@ -174,7 +235,128 @@ def patch_notification_settings(
         settings = crud.upsert_notification_settings(session, payload)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    schedule_backup_after_change()
     return NotificationSettingsRead.model_validate(settings, from_attributes=True)
+
+
+@app.get(
+    "/api/admin/backups/settings",
+    response_model=BackupSettingsRead,
+)
+def get_backup_settings_endpoint(
+    session: Session = Depends(get_session),
+) -> BackupSettingsRead:
+    settings = crud.get_backup_settings(session)
+    return build_backup_settings_response(settings)
+
+
+@app.put(
+    "/api/admin/backups/settings",
+    response_model=BackupSettingsRead,
+)
+def put_backup_settings(
+    payload: BackupSettingsWrite, session: Session = Depends(get_session)
+) -> BackupSettingsRead:
+    try:
+        settings = crud.upsert_backup_settings(session, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    service = _get_backup_service(optional=True)
+    if service is not None:
+        service.apply_settings_change(settings.is_configured)
+    return build_backup_settings_response(settings)
+
+
+@app.patch(
+    "/api/admin/backups/settings",
+    response_model=BackupSettingsRead,
+)
+def patch_backup_settings(
+    payload: BackupSettingsUpdate, session: Session = Depends(get_session)
+) -> BackupSettingsRead:
+    try:
+        settings = crud.upsert_backup_settings(session, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    service = _get_backup_service(optional=True)
+    if service is not None:
+        service.apply_settings_change(settings.is_configured)
+    return build_backup_settings_response(settings)
+
+
+@app.post("/api/admin/backups/run")
+async def run_backup_now(
+    service: BackupService = Depends(require_backup_service),
+) -> Dict[str, object]:
+    result = await service.run_immediately()
+    response: Dict[str, object] = {
+        "success": result.success,
+        "message": result.message,
+        "timestamp": result.timestamp,
+    }
+    if result.file_name:
+        response["file_name"] = result.file_name
+    if result.file_id:
+        response["file_id"] = result.file_id
+    if result.size_bytes is not None:
+        response["size_bytes"] = result.size_bytes
+    return response
+
+
+@app.post("/api/admin/backups/import")
+async def import_database(file: UploadFile = File(...)) -> Dict[str, str]:
+    filename = (file.filename or "").lower()
+    if not filename.endswith(".db"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Upload a valid SQLite .db file.",
+        )
+    temp_path = Path(DATABASE_PATH) / f"import-{uuid4().hex}.db"
+    try:
+        with temp_path.open("wb") as buffer:
+            while True:
+                chunk = await file.read(1024 * 1024)
+                if not chunk:
+                    break
+                buffer.write(chunk)
+    finally:
+        await file.close()
+
+    if not temp_path.exists() or temp_path.stat().st_size == 0:
+        if temp_path.exists():
+            temp_path.unlink()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Uploaded database file is empty.",
+        )
+
+    target_path = DATABASE_FILE
+    backup_path = target_path.with_suffix(".bak")
+
+    try:
+        if target_path.exists():
+            if backup_path.exists():
+                backup_path.unlink()
+            target_path.replace(backup_path)
+        shutil.move(temp_path, target_path)
+        engine.dispose()
+        init_db()
+    except Exception as exc:  # pragma: no cover - defensive guard
+        if temp_path.exists():
+            temp_path.unlink()
+        if target_path.exists():
+            target_path.unlink()
+        if backup_path.exists():
+            backup_path.replace(target_path)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to import database.",
+        ) from exc
+
+    if backup_path.exists():
+        backup_path.unlink()
+    schedule_backup_after_change()
+    return {"status": "imported"}
 
 
 @app.post(
@@ -222,6 +404,7 @@ def create_card(
 ) -> CreditCardWithBenefits:
     card = crud.create_credit_card(session, payload)
     session.refresh(card)
+    schedule_backup_after_change()
     return build_card_response(session, card)
 
 
@@ -231,6 +414,7 @@ def update_card(
 ) -> CreditCardWithBenefits:
     card = require_card(session, card_id)
     updated = crud.update_credit_card(session, card, payload)
+    schedule_backup_after_change()
     return build_card_response(session, updated)
 
 
@@ -242,6 +426,7 @@ def update_card(
 def delete_card(card_id: int, session: Session = Depends(get_session)) -> Response:
     card = require_card(session, card_id)
     crud.delete_credit_card(session, card)
+    schedule_backup_after_change()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -256,6 +441,7 @@ def add_benefit(
     card = require_card(session, card_id)
     benefit = crud.create_benefit(session, card, payload)
     session.refresh(benefit)
+    schedule_backup_after_change()
     return build_enriched_benefit(session, benefit, card)
 
 
@@ -271,6 +457,7 @@ def update_benefit(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(exc),
         ) from exc
+    schedule_backup_after_change()
     return build_enriched_benefit(session, updated)
 
 
@@ -285,6 +472,7 @@ def set_benefit_usage(
             detail="Usage toggles are only supported for standard benefits.",
         )
     updated = crud.set_benefit_usage(session, benefit, payload)
+    schedule_backup_after_change()
     return build_enriched_benefit(session, updated)
 
 
@@ -316,6 +504,7 @@ def create_benefit_redemption(
     benefit = require_benefit(session, benefit_id)
     created = crud.create_benefit_redemption(session, benefit, payload)
     session.refresh(created)
+    schedule_backup_after_change()
     return BenefitRedemptionRead.model_validate(created, from_attributes=True)
 
 
@@ -330,6 +519,7 @@ def update_benefit_redemption(
 ) -> BenefitRedemptionRead:
     redemption = require_redemption(session, redemption_id)
     updated = crud.update_benefit_redemption(session, redemption, payload)
+    schedule_backup_after_change()
     return BenefitRedemptionRead.model_validate(updated, from_attributes=True)
 
 
@@ -343,6 +533,7 @@ def delete_benefit_redemption(
 ) -> Response:
     redemption = require_redemption(session, redemption_id)
     crud.delete_benefit_redemption(session, redemption)
+    schedule_backup_after_change()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -355,6 +546,7 @@ def delete_benefit(benefit_id: int, session: Session = Depends(get_session)) -> 
     benefit = require_benefit(session, benefit_id)
     session.delete(benefit)
     session.commit()
+    schedule_backup_after_change()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -101,3 +101,28 @@ class NotificationSettings(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
+
+class BackupSettings(SQLModel, table=True):
+    """Configuration required to upload database backups to Google Drive."""
+
+    id: Optional[int] = Field(default=1, primary_key=True)
+    drive_folder_id: str = Field(description="Target Google Drive folder identifier")
+    service_account_json: str = Field(
+        description="Raw JSON credentials for the Google service account",
+    )
+    service_account_email: Optional[str] = Field(
+        default=None,
+        description="Derived service account email for display purposes",
+    )
+    last_backup_at: Optional[datetime] = Field(default=None)
+    last_backup_file_id: Optional[str] = Field(default=None)
+    last_backup_filename: Optional[str] = Field(default=None)
+    last_backup_size: Optional[int] = Field(default=None, ge=0)
+    last_backup_error: Optional[str] = Field(default=None)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.drive_folder_id and self.service_account_json)
+

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -256,6 +256,69 @@ class NotificationDispatchResult(SQLModel):
     categories: Dict[str, List[NotificationBenefitSummary]] = Field(default_factory=dict)
 
 
+class BackupSettingsBase(SQLModel):
+    drive_folder_id: str
+
+    @field_validator("drive_folder_id")
+    @classmethod
+    def validate_drive_folder_id(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("A Google Drive folder ID is required.")
+        return cleaned
+
+
+class BackupSettingsWrite(BackupSettingsBase):
+    service_account_json: str
+
+    @field_validator("service_account_json")
+    @classmethod
+    def validate_service_account_json(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Service account credentials are required.")
+        return cleaned
+
+
+class BackupSettingsUpdate(SQLModel):
+    drive_folder_id: Optional[str] = None
+    service_account_json: Optional[str] = None
+
+    @field_validator("drive_folder_id")
+    @classmethod
+    def normalise_drive_folder_id(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("A Google Drive folder ID is required when provided.")
+        return cleaned
+
+    @field_validator("service_account_json")
+    @classmethod
+    def normalise_service_account_json(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Service account credentials cannot be blank.")
+        return cleaned
+
+
+class BackupSettingsRead(SQLModel):
+    drive_folder_id: Optional[str] = None
+    service_account_email: Optional[str] = None
+    is_configured: bool = False
+    last_backup_at: Optional[datetime] = None
+    last_backup_filename: Optional[str] = None
+    last_backup_size: Optional[int] = Field(default=None, ge=0)
+    last_backup_error: Optional[str] = None
+    next_backup_at: Optional[datetime] = None
+    last_result_at: Optional[datetime] = None
+    last_result_message: Optional[str] = None
+    last_result_success: Optional[bool] = None
+
+
 class PreconfiguredBenefitBase(SQLModel):
     name: str
     description: Optional[str] = None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,6 @@ sqlmodel==0.0.14
 pydantic==2.9.2
 sqlalchemy==2.0.34
 httpx==0.27.2
+google-api-python-client==2.147.0
+google-auth==2.35.0
+google-auth-httplib2==0.2.0

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -73,9 +73,45 @@ const notificationTestResults = reactive({
   daily: null
 })
 
+const backupSettings = reactive({
+  drive_folder_id: '',
+  service_account_email: '',
+  is_configured: false,
+  last_backup_at: null,
+  last_backup_filename: '',
+  last_backup_size: null,
+  last_backup_error: '',
+  next_backup_at: null,
+  last_result_at: null,
+  last_result_message: '',
+  last_result_success: null
+})
+
+const backupForm = reactive({
+  drive_folder_id: '',
+  service_account_json: ''
+})
+
+const backupState = reactive({
+  loading: false,
+  saving: false,
+  running: false,
+  importing: false,
+  error: '',
+  success: '',
+  runMessage: '',
+  runSuccess: null,
+  importError: '',
+  importSuccess: ''
+})
+
+const backupImportFile = ref(null)
+const backupFileInput = ref(null)
+
 const isDashboardView = computed(() => currentView.value === 'dashboard')
 const isBenefitsView = computed(() => currentView.value === 'benefits')
 const isAdminView = computed(() => currentView.value === 'admin')
+const isBackupConfigured = computed(() => backupSettings.is_configured)
 
 function setView(view) {
   currentView.value = view
@@ -112,6 +148,16 @@ watch(
     }
     notificationSettingsError.value = ''
     notificationSettingsSuccess.value = ''
+  }
+)
+
+watch(
+  () => [backupForm.drive_folder_id, backupForm.service_account_json],
+  () => {
+    if (!backupState.loading) {
+      backupState.error = ''
+      backupState.success = ''
+    }
   }
 )
 
@@ -164,6 +210,64 @@ function extractErrorMessage(err, fallback) {
   return fallback
 }
 
+function resetBackupSettings() {
+  backupSettings.drive_folder_id = ''
+  backupSettings.service_account_email = ''
+  backupSettings.is_configured = false
+  backupSettings.last_backup_at = null
+  backupSettings.last_backup_filename = ''
+  backupSettings.last_backup_size = null
+  backupSettings.last_backup_error = ''
+  backupSettings.next_backup_at = null
+  backupSettings.last_result_at = null
+  backupSettings.last_result_message = ''
+  backupSettings.last_result_success = null
+  backupForm.drive_folder_id = ''
+}
+
+function applyBackupSettings(data) {
+  if (!data || typeof data !== 'object') {
+    resetBackupSettings()
+    return
+  }
+  backupSettings.drive_folder_id = data.drive_folder_id ?? ''
+  backupSettings.service_account_email = data.service_account_email ?? ''
+  backupSettings.is_configured = data.is_configured === true
+  backupSettings.last_backup_at = data.last_backup_at ?? null
+  backupSettings.last_backup_filename = data.last_backup_filename ?? ''
+  backupSettings.last_backup_size =
+    typeof data.last_backup_size === 'number' ? data.last_backup_size : null
+  backupSettings.last_backup_error = data.last_backup_error ?? ''
+  backupSettings.next_backup_at = data.next_backup_at ?? null
+  backupSettings.last_result_at = data.last_result_at ?? null
+  backupSettings.last_result_message = data.last_result_message ?? ''
+  if (data.last_result_success === true) {
+    backupSettings.last_result_success = true
+  } else if (data.last_result_success === false) {
+    backupSettings.last_result_success = false
+  } else {
+    backupSettings.last_result_success = null
+  }
+  backupForm.drive_folder_id = backupSettings.drive_folder_id
+}
+
+function formatBackupSize(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return ''
+  }
+  if (bytes < 1024) {
+    return `${bytes} B`
+  }
+  const units = ['KB', 'MB', 'GB']
+  let size = bytes / 1024
+  let unitIndex = 0
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex += 1
+  }
+  return `${size.toFixed(1)} ${units[unitIndex]}`
+}
+
 async function loadNotificationSettings() {
   notificationSettingsLoading.value = true
   notificationSettingsLoaded.value = false
@@ -184,6 +288,20 @@ async function loadNotificationSettings() {
   } finally {
     notificationSettingsLoading.value = false
     notificationSettingsLoaded.value = true
+  }
+}
+
+async function loadBackupSettings() {
+  backupState.loading = true
+  backupState.error = ''
+  try {
+    const response = await apiClient.get('/api/admin/backups/settings')
+    applyBackupSettings(response.data)
+  } catch (err) {
+    resetBackupSettings()
+    backupState.error = extractErrorMessage(err, 'Unable to load backup settings.')
+  } finally {
+    backupState.loading = false
   }
 }
 
@@ -215,6 +333,105 @@ async function saveNotificationSettings() {
     )
   } finally {
     notificationSettingsSaving.value = false
+  }
+}
+
+async function saveBackupSettings() {
+  backupState.error = ''
+  backupState.success = ''
+  const folderId = backupForm.drive_folder_id.trim()
+  const credentials = backupForm.service_account_json.trim()
+  if (!folderId) {
+    backupState.error = 'Provide the Google Drive folder ID before saving.'
+    return
+  }
+  if (!isBackupConfigured.value && !credentials) {
+    backupState.error = 'Paste the service account JSON credentials to configure backups.'
+    return
+  }
+  const payload = { drive_folder_id: folderId }
+  let method = 'patch'
+  if (!isBackupConfigured.value) {
+    payload.service_account_json = credentials
+    method = 'put'
+  } else if (credentials) {
+    payload.service_account_json = credentials
+  }
+  backupState.saving = true
+  try {
+    const response =
+      method === 'put'
+        ? await apiClient.put('/api/admin/backups/settings', payload)
+        : await apiClient.patch('/api/admin/backups/settings', payload)
+    applyBackupSettings(response.data)
+    backupForm.service_account_json = ''
+    backupState.success = 'Backup settings saved.'
+  } catch (err) {
+    backupState.error = extractErrorMessage(err, 'Unable to save backup settings.')
+  } finally {
+    backupState.saving = false
+  }
+}
+
+async function runBackupNow() {
+  backupState.runMessage = ''
+  backupState.runSuccess = null
+  backupState.error = ''
+  if (!isBackupConfigured.value) {
+    backupState.error = 'Configure Google Drive backups before running a backup.'
+    return
+  }
+  backupState.running = true
+  try {
+    const response = await apiClient.post('/api/admin/backups/run')
+    const data = response.data || {}
+    backupState.runMessage = data.message || 'Backup task completed.'
+    backupState.runSuccess = data.success !== false
+    await loadBackupSettings()
+  } catch (err) {
+    backupState.runMessage = extractErrorMessage(err, 'Unable to run the backup now.')
+    backupState.runSuccess = false
+  } finally {
+    backupState.running = false
+  }
+}
+
+function handleBackupFileChange(event) {
+  const fileList = event?.target?.files || []
+  backupImportFile.value = fileList.length ? fileList[0] : null
+  backupState.importError = ''
+  backupState.importSuccess = ''
+}
+
+async function importBackupDatabase() {
+  backupState.importError = ''
+  backupState.importSuccess = ''
+  if (!backupImportFile.value) {
+    backupState.importError = 'Select a .db file to import.'
+    return
+  }
+  const formData = new FormData()
+  formData.append('file', backupImportFile.value)
+  backupState.importing = true
+  try {
+    await apiClient.post('/api/admin/backups/import', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+    backupState.importSuccess = 'Database imported successfully.'
+    backupImportFile.value = null
+    if (backupFileInput.value) {
+      backupFileInput.value.value = ''
+    }
+    await Promise.all([
+      loadCards(),
+      loadPreconfiguredCards(),
+      loadNotificationSettings(),
+      loadBackupSettings()
+    ])
+  } catch (err) {
+    backupState.importError = extractErrorMessage(err, 'Unable to import the database file.')
+  } finally {
+    backupState.importing = false
   }
 }
 
@@ -1467,6 +1684,7 @@ function closeHistoryModal() {
 }
 
 onMounted(async () => {
+  await loadBackupSettings()
   await loadNotificationSettings()
   await loadFrequencies()
   await loadPreconfiguredCards()
@@ -1623,6 +1841,150 @@ onMounted(async () => {
       </template>
 
       <template v-else>
+        <section class="section-card admin-board content-constrained">
+          <div class="section-header">
+            <div>
+              <h2 class="section-title">Database backups</h2>
+              <p class="section-description">
+                Configure automatic Google Drive backups and restore from an archived database file.
+              </p>
+            </div>
+          </div>
+          <div v-if="backupState.loading" class="empty-state">Loading backup settings...</div>
+          <template v-else>
+            <form class="admin-settings-form backup-settings-form" @submit.prevent="saveBackupSettings">
+              <div class="field-group">
+                <input
+                  v-model="backupForm.drive_folder_id"
+                  type="text"
+                  placeholder="Google Drive folder ID"
+                  required
+                />
+              </div>
+              <textarea
+                v-model="backupForm.service_account_json"
+                rows="4"
+                placeholder="Service account JSON (paste to set or rotate credentials)"
+              ></textarea>
+              <p class="helper-text subtle-text">
+                Use a service account with access to the destination folder. Backups run one hour after the most recent change.
+              </p>
+              <div class="backup-settings-feedback">
+                <p v-if="backupState.error" class="helper-text error-text">{{ backupState.error }}</p>
+                <p v-else-if="backupState.success" class="helper-text success-text">{{ backupState.success }}</p>
+              </div>
+              <div class="backup-settings-actions">
+                <button class="primary-button" type="submit" :disabled="backupState.saving">
+                  {{ backupState.saving ? 'Saving…' : 'Save backup settings' }}
+                </button>
+              </div>
+            </form>
+
+            <div class="backup-status-grid">
+              <div class="backup-status-card">
+                <h3 class="backup-status-title">Configuration</h3>
+                <p class="backup-status-line">
+                  Status
+                  <span class="tag" :class="isBackupConfigured ? 'success' : 'warning'">
+                    {{ isBackupConfigured ? 'Configured' : 'Not configured' }}
+                  </span>
+                </p>
+                <p class="backup-status-line">
+                  Service account ·
+                  <span class="backup-status-value">
+                    {{ backupSettings.service_account_email || 'Not set' }}
+                  </span>
+                </p>
+              </div>
+              <div class="backup-status-card">
+                <h3 class="backup-status-title">Schedule</h3>
+                <p v-if="backupSettings.next_backup_at" class="backup-status-line">
+                  Next backup {{ formatNotificationTimestamp(backupSettings.next_backup_at) }}
+                </p>
+                <p v-else-if="isBackupConfigured" class="backup-status-line subtle-text">
+                  Waiting for recent changes before scheduling.
+                </p>
+                <p v-else class="backup-status-line subtle-text">
+                  Configure backups to enable scheduling.
+                </p>
+              </div>
+              <div class="backup-status-card">
+                <h3 class="backup-status-title">Last backup</h3>
+                <p v-if="backupSettings.last_backup_at" class="backup-status-line">
+                  Saved {{ formatNotificationTimestamp(backupSettings.last_backup_at) }}
+                </p>
+                <p v-else class="backup-status-line subtle-text">No backups have been created yet.</p>
+                <p v-if="backupSettings.last_backup_filename" class="backup-status-line">
+                  File · <span class="backup-status-value">{{ backupSettings.last_backup_filename }}</span>
+                </p>
+                <p v-if="backupSettings.last_backup_size !== null" class="backup-status-line">
+                  Size · <span class="backup-status-value">{{ formatBackupSize(backupSettings.last_backup_size) }}</span>
+                </p>
+                <p v-if="backupSettings.last_backup_error" class="helper-text error-text">
+                  {{ backupSettings.last_backup_error }}
+                </p>
+              </div>
+              <div class="backup-status-card">
+                <h3 class="backup-status-title">Recent run</h3>
+                <p v-if="backupSettings.last_result_at" class="backup-status-line">
+                  {{ backupSettings.last_result_success === false ? 'Failed' : 'Completed' }}
+                  {{ formatNotificationTimestamp(backupSettings.last_result_at) }}
+                </p>
+                <p v-if="backupSettings.last_result_message" class="backup-status-line">
+                  {{ backupSettings.last_result_message }}
+                </p>
+                <p v-else class="backup-status-line subtle-text">No backup activity yet.</p>
+              </div>
+            </div>
+
+            <div class="backup-actions-row">
+              <button
+                class="primary-button secondary"
+                type="button"
+                :disabled="backupState.running || !isBackupConfigured"
+                @click="runBackupNow"
+              >
+                {{ backupState.running ? 'Running…' : 'Run backup now' }}
+              </button>
+              <p
+                v-if="backupState.runMessage"
+                :class="['helper-text', backupState.runSuccess === false ? 'error-text' : 'success-text']"
+              >
+                {{ backupState.runMessage }}
+              </p>
+            </div>
+
+            <div class="backup-import-card">
+              <h3 class="backup-import-title">Import database</h3>
+              <p class="helper-text subtle-text">
+                Upload a SQLite <code>.db</code> file to replace the current database. A backup will be scheduled automatically after import.
+              </p>
+              <div class="backup-import-controls">
+                <input
+                  ref="backupFileInput"
+                  type="file"
+                  accept=".db"
+                  @change="handleBackupFileChange"
+                />
+                <button
+                  class="primary-button secondary"
+                  type="button"
+                  :disabled="backupState.importing"
+                  @click="importBackupDatabase"
+                >
+                  {{ backupState.importing ? 'Importing…' : 'Import database' }}
+                </button>
+              </div>
+              <p v-if="backupState.importError" class="helper-text error-text">
+                {{ backupState.importError }}
+              </p>
+              <p v-else-if="backupState.importSuccess" class="helper-text success-text">
+                {{ backupState.importSuccess }}
+              </p>
+            </div>
+          </template>
+        </section>
+
         <section class="section-card admin-board content-constrained">
           <div class="section-header">
             <div>

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -362,6 +362,101 @@ textarea {
   gap: 1rem;
 }
 
+.backup-settings-form textarea {
+  font-family: inherit;
+  resize: vertical;
+  min-height: 120px;
+}
+
+.backup-settings-feedback {
+  min-height: 1.25rem;
+}
+
+.backup-settings-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.backup-status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.backup-status-card {
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  border-radius: 14px;
+  background: rgba(248, 250, 252, 0.75);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.backup-status-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.backup-status-line {
+  margin: 0;
+  font-size: 0.92rem;
+  color: #1e293b;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.backup-status-line.subtle-text {
+  color: #64748b;
+}
+
+.backup-status-value {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.backup-actions-row {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.backup-import-card {
+  margin-top: 1.5rem;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  border-radius: 14px;
+  background: rgba(248, 250, 252, 0.75);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.backup-import-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.backup-import-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.backup-import-controls input[type='file'] {
+  font: inherit;
+}
+
 .notification-field-group {
   align-items: center;
 }


### PR DESCRIPTION
## Summary
- add a background backup service that uploads monthly SQLite archives to Google Drive using service account credentials
- expose admin APIs to configure Google Drive backups, trigger a run, and import a replacement database
- refresh the Vue admin panel with a dedicated backups card plus styles and document the workflow in the README

## Testing
- npm run build
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d53b3f3414832e99cbce4cf18caca6