### PR TITLE
Add automated SMB backups and restore tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ CreditWatch is a local-first dashboard for tracking credit cards, their annual f
 - ✅ Mark benefits as used to keep a running tally of realized value versus your annual fees.
 - 📊 Gorgeous, card-based Vue 3 interface with at-a-glance progress bars for each credit card.
 - 🗂️ SQLite persistence so your data lives alongside the app when run locally or inside Docker.
+- 💾 Automated SMB backups with monthly retention plus one-click restores from the admin panel.
 
 ## Project layout
 
@@ -66,8 +67,22 @@ The backend exposes a REST API under `/api`. The most important endpoints are:
 | POST   | `/api/benefits/{benefit_id}/usage`    | Mark a benefit as used or reset it.          |
 | DELETE | `/api/benefits/{benefit_id}`          | Remove a benefit from a card.                |
 | GET    | `/api/frequencies`                    | Enumerate available benefit frequencies.     |
+| GET    | `/api/admin/backup/settings`          | Retrieve the SMB backup configuration.       |
+| PUT    | `/api/admin/backup/settings`          | Create or replace SMB backup settings.       |
+| PATCH  | `/api/admin/backup/settings`          | Partially update SMB backup settings.        |
+| POST   | `/api/admin/backup/import`            | Replace the database with an uploaded file.  |
 
 FastAPI automatically exposes interactive docs at [http://localhost:8010/docs](http://localhost:8010/docs).
+
+## Database backups
+
+The **Backups** card in the admin panel manages database resilience:
+
+- Provide the SMB server, share, optional subfolder, username, and password to enable hourly backups.
+- CreditWatch waits an hour after the most recent data change before copying the SQLite database to the share. Each month is stored as a single `creditwatch-YYYY-MM.db` snapshot so older months remain available.
+- Uploading a `*.db` file restores that snapshot immediately and reinitialises the schema. This operation overwrites any unsaved changes, so keep a backup handy.
+
+These features rely on the [`smbprotocol`](https://pypi.org/project/smbprotocol/) client library, which ships with the backend requirements.
 
 ## Using the app
 

--- a/backend/app/backup.py
+++ b/backend/app/backup.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sqlite3
+import tempfile
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+import smbclient
+from fastapi import FastAPI
+from sqlmodel import Session
+
+from . import crud
+from .database import DATABASE_PATH
+
+logger = logging.getLogger("creditwatch.backup")
+
+
+@dataclass
+class BackupConfig:
+    id: int
+    server: str
+    share: str
+    directory: str
+    username: str
+    password: str
+    domain: Optional[str]
+
+
+class BackupService:
+    """Background service that coordinates automated SMB backups."""
+
+    def __init__(self, *, engine) -> None:
+        self._engine = engine
+        self._task: asyncio.Task[None] | None = None
+        self._event = asyncio.Event()
+        self._last_change: datetime | None = None
+        self._next_run: datetime | None = None
+
+    def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if self._task is None:
+            return
+        self._task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+
+    def register_change(self) -> None:
+        """Mark that the database content has changed."""
+
+        self._last_change = datetime.utcnow()
+        self._event.set()
+
+    def refresh_settings(self) -> None:
+        """Signal that settings have changed and should be reloaded."""
+
+        self._event.set()
+
+    @property
+    def next_run(self) -> datetime | None:
+        return self._next_run
+
+    async def _run(self) -> None:
+        while True:
+            await self._event.wait()
+            self._event.clear()
+            while True:
+                config = await asyncio.to_thread(self._load_config)
+                change = self._last_change
+                if config is None or change is None:
+                    self._next_run = None
+                    break
+                due_at = change + timedelta(hours=1)
+                now = datetime.utcnow()
+                wait_seconds = (due_at - now).total_seconds()
+                if wait_seconds <= 0:
+                    try:
+                        await asyncio.to_thread(self._perform_backup, config)
+                    except Exception:  # pragma: no cover - defensive logging
+                        logger.exception("Automated backup failed")
+                    finally:
+                        self._last_change = None
+                        self._next_run = None
+                    break
+                self._next_run = due_at
+                try:
+                    await asyncio.wait_for(self._event.wait(), timeout=wait_seconds)
+                except asyncio.TimeoutError:
+                    continue
+                else:
+                    self._event.clear()
+
+    def _load_config(self) -> BackupConfig | None:
+        with Session(self._engine) as session:
+            settings = crud.get_backup_settings(session)
+            if settings is None or not settings.password:
+                return None
+            return BackupConfig(
+                id=settings.id or 1,
+                server=settings.server,
+                share=settings.share,
+                directory=settings.directory or "",
+                username=settings.username,
+                password=settings.password,
+                domain=settings.domain,
+            )
+
+    def _perform_backup(self, config: BackupConfig) -> None:
+        timestamp = datetime.utcnow()
+        filename = f"creditwatch-{timestamp:%Y-%m}.db"
+        temp_fd, temp_path = tempfile.mkstemp(suffix=".db")
+        os.close(temp_fd)
+        temp_file = Path(temp_path)
+        try:
+            self._export_sqlite(temp_file)
+            self._upload_to_smb(config, temp_file, filename)
+        except Exception as exc:
+            with Session(self._engine) as session:
+                settings = crud.get_backup_settings(session)
+                if settings and (settings.id or 1) == config.id:
+                    crud.record_backup_failure(session, settings, str(exc))
+            raise
+        else:
+            with Session(self._engine) as session:
+                settings = crud.get_backup_settings(session)
+                if settings and (settings.id or 1) == config.id:
+                    crud.record_backup_success(
+                        session, settings, timestamp=timestamp, filename=filename
+                    )
+        finally:
+            try:
+                temp_file.unlink()
+            except FileNotFoundError:
+                pass
+
+    def _export_sqlite(self, destination: Path) -> None:
+        source_path = DATABASE_PATH / "creditwatch.db"
+        if not source_path.exists():
+            raise FileNotFoundError("CreditWatch database has not been created yet.")
+        with sqlite3.connect(source_path) as source, sqlite3.connect(destination) as target:
+            source.backup(target)
+
+    def _upload_to_smb(self, config: BackupConfig, source: Path, filename: str) -> None:
+        smbclient.reset_connection_cache()
+        remote_base = f"//{config.server}/{config.share}"
+        directory = config.directory.replace("\\", "/").strip("/")
+        remote_dir = f"{remote_base}/{directory}" if directory else remote_base
+        remote_path = f"{remote_dir}/{filename}"
+        smbclient.register_session(
+            config.server,
+            username=config.username,
+            password=config.password,
+            domain=config.domain,
+        )
+        smbclient.mkdirs(remote_dir, exist_ok=True)
+        with smbclient.open_file(remote_path, mode="wb", buffering=0) as remote_file:
+            with source.open("rb") as local_file:
+                while True:
+                    chunk = local_file.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    remote_file.write(chunk)
+        smbclient.reset_connection_cache()
+
+
+def schedule_backup_after_change(app: FastAPI) -> None:
+    service: BackupService | None = getattr(app.state, "backup_service", None)
+    if service is not None:
+        service.register_change()
+
+
+def refresh_backup_settings(app: FastAPI) -> None:
+    service: BackupService | None = getattr(app.state, "backup_service", None)
+    if service is not None:
+        service.refresh_settings()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -101,3 +101,26 @@ class NotificationSettings(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
+
+class BackupSettings(SQLModel, table=True):
+    """Configuration for automated SMB database backups."""
+
+    id: Optional[int] = Field(default=1, primary_key=True)
+    server: str = Field(description="Hostname or IP address of the SMB server")
+    share: str = Field(description="Share name that will store database backups")
+    directory: str = Field(
+        default="",
+        description="Optional subdirectory within the share for database backups",
+    )
+    username: str = Field(description="SMB account used to authenticate")
+    password: str = Field(description="SMB account password")
+    domain: Optional[str] = Field(
+        default=None,
+        description="Optional domain or workgroup for authentication",
+    )
+    last_backup_at: Optional[datetime] = None
+    last_backup_filename: Optional[str] = None
+    last_backup_error: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -212,6 +212,108 @@ class NotificationSettingsRead(NotificationSettingsBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class BackupSettingsBase(SQLModel):
+    server: str
+    share: str
+    directory: str = Field(default="")
+    username: str
+    domain: Optional[str] = None
+
+    @field_validator("server", "share", "username", mode="before")
+    @classmethod
+    def validate_required_field(cls, value: str) -> str:
+        cleaned = str(value or "").strip()
+        if not cleaned:
+            raise ValueError("This field cannot be empty.")
+        return cleaned
+
+    @field_validator("directory", mode="before")
+    @classmethod
+    def normalise_directory(cls, value: str) -> str:
+        if value is None:
+            return ""
+        cleaned = str(value).strip().strip("/\\")
+        return cleaned
+
+    @field_validator("domain", mode="before")
+    @classmethod
+    def normalise_domain(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = str(value).strip()
+        return cleaned or None
+
+
+class BackupSettingsWrite(BackupSettingsBase):
+    password: str
+
+    @field_validator("password", mode="before")
+    @classmethod
+    def validate_password(cls, value: str) -> str:
+        cleaned = str(value or "").strip()
+        if not cleaned:
+            raise ValueError("Password is required.")
+        return cleaned
+
+
+class BackupSettingsUpdate(SQLModel):
+    server: Optional[str] = None
+    share: Optional[str] = None
+    directory: Optional[str] = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+    domain: Optional[str] = None
+
+    @field_validator("server", "share", "username", mode="before")
+    @classmethod
+    def trim_required_optional(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = str(value).strip()
+        if not cleaned:
+            raise ValueError("This field cannot be empty.")
+        return cleaned
+
+    @field_validator("password", mode="before")
+    @classmethod
+    def trim_password(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = str(value).strip()
+        if not cleaned:
+            raise ValueError("Password cannot be empty.")
+        return cleaned
+
+    @field_validator("directory", mode="before")
+    @classmethod
+    def trim_directory(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = str(value).strip().strip("/\\")
+        return cleaned
+
+    @field_validator("domain", mode="before")
+    @classmethod
+    def trim_domain(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = str(value).strip()
+        return cleaned if cleaned else None
+
+
+class BackupSettingsRead(BackupSettingsBase):
+    id: int
+    last_backup_at: Optional[datetime] = None
+    last_backup_filename: Optional[str] = None
+    last_backup_error: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+    next_backup_at: Optional[datetime] = None
+    has_password: bool = False
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class NotificationSettingsWrite(NotificationSettingsBase):
     pass
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ sqlmodel==0.0.14
 pydantic==2.9.2
 sqlalchemy==2.0.34
 httpx==0.27.2
+smbprotocol==1.11.0

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -457,6 +457,98 @@ textarea {
   margin-top: 0.6rem;
 }
 
+.backup-grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+@media (min-width: 900px) {
+  .backup-grid {
+    grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
+  }
+}
+
+.backup-settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.backup-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.backup-status-card {
+  border: 1px solid rgba(226, 232, 240, 0.7);
+  border-radius: 16px;
+  background: rgba(248, 250, 252, 0.85);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+.backup-status-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.backup-status-list {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.backup-status-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.backup-status-entry dt {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.backup-status-entry dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #0f172a;
+  font-weight: 500;
+}
+
+.backup-import-form {
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  padding-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.backup-import-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.backup-import-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.backup-messages .helper-text {
+  margin: 0;
+}
+
 .notification-category h4 {
   margin: 0 0 0.25rem;
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- add an async backup service with SMB upload support plus REST endpoints for configuring backups and importing database files
- surface a new Backups card in the admin UI to manage SMB settings, show backup status, and upload `.db` restores
- document the new dependency and backup workflow in the README

## Testing
- npm run build
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d554c4aef4832e8af81bcd08b59b18