### PR TITLE
Allow configuring notify services via blueprint inputs

### DIFF
--- a/backend/integrations/home_assistant_notification.yaml
+++ b/backend/integrations/home_assistant_notification.yaml
@@ -3,14 +3,9 @@
 # Import this file into Home Assistant (Settings → Automations & Scenes → Import blueprint)
 # to create an automation that listens for webhook calls from the CreditWatch backend.
 # Set the ``Webhook ID`` blueprint input to the identifier configured in the backend.
-# Update the ``target_map`` dictionary with the notification services that correspond
-# to your devices. The backend will send a ``target`` slug that maps to one of these keys.
-# Each entry should be a list so multiple notify services can be triggered for a single
-# target.
-#
-# Example: if your mobile device is exposed as ``notify.mobile_app_janes_iphone`` and you
-# want it to be the default target, configure the backend with ``default_target: primary``
-# and set ``primary`` to a list containing that notify service below.
+# Provide the notify services in the blueprint inputs. Configure the CreditWatch backend
+# with a ``default_target`` slug (``default`` is used when no slug is provided) and optional
+# overrides that map to the entries you configure below.
 blueprint:
   name: CreditWatch notification webhook
   description: Handle CreditWatch reminder notifications via a webhook
@@ -23,6 +18,24 @@ blueprint:
       selector:
         text:
       default: creditwatch
+    notify_services:
+      name: Default notify services
+      description: |
+        YAML list of Home Assistant notify services that should receive notifications when
+        no target override is provided by the backend.
+      selector:
+        object:
+      default:
+        - notify.mobile_app_example_device
+    target_overrides:
+      name: Target overrides
+      description: |
+        (Optional) YAML mapping of target slugs to lists of notify services. Use this when
+        the backend is configured with additional target slugs and you want each slug to
+        deliver to a different set of notify services.
+      selector:
+        object:
+      default: {}
 
 trigger:
   - platform: webhook
@@ -34,19 +47,18 @@ trigger:
 variables:
   payload: "{{ trigger.json | default({}) }}"
   target_slug: "{{ payload.target | default('default') }}"
-  default_target: default
-  target_map:
-    default:
-      - notify.mobile_app_example_device
-    # primary:
-    #   - notify.mobile_app_primary_phone
-    #   - notify.mobile_app_secondary_phone
-    # tablet:
-    #   - notify.mobile_app_kitchen_tablet
+  default_notify_services: !input notify_services
+  target_overrides: !input target_overrides
   notify_services: >-
-    {% set services = target_map.get(target_slug, target_map.default) %}
+    {% set overrides = target_overrides if target_overrides is mapping else {} %}
+    {% set services = overrides.get(target_slug, default_notify_services) %}
+    {% if services in (none, '') %}
+      {% set services = default_notify_services %}
+    {% endif %}
     {% if services is string %}
       {{ [services] }}
+    {% elif services is mapping %}
+      {{ services.values() | list }}
     {% else %}
       {{ services | list }}
     {% endif %}


### PR DESCRIPTION
## Summary
- add blueprint inputs for supplying default notify services and optional target overrides
- derive the notify service list from the configured inputs instead of editing the YAML file manually

## Testing
- not run (blueprint change only)


------
https://chatgpt.com/codex/tasks/task_e_68d55d97b5d4832e9280b7be3a7ca445