### PR TITLE
Add admin tooling for backup controls and notification history

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from sqlalchemy import JSON, Column
 from sqlmodel import Field, SQLModel
@@ -123,4 +123,24 @@ class BackupSettings(SQLModel, table=True):
     last_backup_error: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class NotificationLog(SQLModel, table=True):
+    """Historical record of notification dispatch attempts."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    event_type: str = Field(index=True, description="Type of notification that was triggered")
+    title: Optional[str] = Field(default=None, description="Title sent to Home Assistant")
+    body: Optional[str] = Field(default=None, description="Body content sent to Home Assistant")
+    target: Optional[str] = Field(default=None, description="Notification target used for delivery")
+    sent: bool = Field(default=False, description="Whether the webhook call was successful")
+    response_message: Optional[str] = Field(
+        default=None, description="Human readable outcome message from the dispatcher"
+    )
+    categories: Dict[str, object] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False, default=dict),
+        description="Summary payload that accompanied the notification",
+    )
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -314,6 +314,24 @@ class BackupSettingsRead(BackupSettingsBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class BackupConnectionTestRequest(BackupSettingsBase):
+    password: Optional[str] = None
+    use_stored_password: bool = Field(default=False)
+
+    @field_validator("password", mode="before")
+    @classmethod
+    def trim_optional_password(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = str(value).strip()
+        return cleaned or None
+
+
+class BackupConnectionTestResult(SQLModel):
+    ok: bool
+    detail: str
+
+
 class NotificationSettingsWrite(NotificationSettingsBase):
     pass
 
@@ -356,6 +374,21 @@ class NotificationDispatchResult(SQLModel):
     sent: bool
     message: Optional[str] = None
     categories: Dict[str, List[NotificationBenefitSummary]] = Field(default_factory=dict)
+    target: Optional[str] = None
+
+
+class NotificationLogRead(SQLModel):
+    id: int
+    event_type: str
+    title: Optional[str] = None
+    body: Optional[str] = None
+    target: Optional[str] = None
+    sent: bool
+    response_message: Optional[str] = None
+    categories: Dict[str, List[NotificationBenefitSummary]] = Field(default_factory=dict)
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class PreconfiguredBenefitBase(SQLModel):

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -478,6 +478,11 @@ textarea {
 .backup-actions {
   display: flex;
   justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.backup-test-messages {
+  min-height: 1.25rem;
 }
 
 .backup-status-card {
@@ -495,6 +500,19 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.backup-run-feedback {
+  min-height: 1.25rem;
+}
+
+.backup-status-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.backup-status-actions .primary-button {
+  align-self: flex-start;
 }
 
 .backup-status-list {
@@ -829,6 +847,62 @@ textarea {
 .history-loading {
   font-size: 0.9rem;
   color: #475569;
+}
+
+.notification-history-table-wrapper {
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  border-radius: 16px;
+  overflow: hidden;
+  max-height: 24rem;
+  overflow-y: auto;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.notification-history-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #ffffff;
+}
+
+.notification-history-table th,
+.notification-history-table td {
+  padding: 0.65rem 0.85rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+  font-size: 0.9rem;
+  color: #1e293b;
+}
+
+.notification-history-table th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+  background: rgba(248, 250, 252, 0.8);
+}
+
+.notification-history-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.status-pill.success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #047857;
+}
+
+.status-pill.error {
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
 }
 
 .primary-button {


### PR DESCRIPTION
## Summary
- log every notification dispatch in a new notification history table and expose an admin endpoint to review recent entries
- expand SMB backup tooling with connection testing, manual run support, and supporting API schemas
- update the admin UI with history/test dialogs, run-now buttons, and confirmation prompts when editing or deleting cards and benefits

## Testing
- python -m compileall backend/app
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d55b9d4d0c832e8918fecf2dc37402