### PR TITLE
Fix admin benefit deletion and reposition remove control

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -356,6 +356,16 @@ textarea {
   gap: 0.6rem;
 }
 
+.admin-benefit-card__footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.25rem;
+}
+
+.admin-benefit-card__remove {
+  margin-left: auto;
+}
+
 .admin-settings-form {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- ensure admin benefit rows carry stable identifiers so deletions persist when saving templates
- move the delete control to the bottom-right of each admin benefit card and style it as a destructive action

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d570b3e844832e9424e7dce431cb8e