### PR TITLE
Add file lock around database initialization

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ sqlalchemy==2.0.34
 httpx==0.27.2
 smbprotocol==1.11.0
 python-multipart==0.0.20
+filelock==3.16.1


### PR DESCRIPTION
## Summary
- serialize database initialization work across uvicorn workers using a shared file lock
- add the filelock dependency for the backend runtime

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d684383538832e9be1c051113b8eea