### PR TITLE
Add per-benefit window alignment and standard redemption flow

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -69,6 +69,7 @@ def _run_database_initialisation_steps() -> None:
     ensure_company_name_column()
     ensure_benefit_type_column()
     ensure_benefit_window_values_column()
+    ensure_benefit_window_tracking_column()
     ensure_card_year_tracking_column()
 
 
@@ -192,6 +193,19 @@ def ensure_benefit_window_values_column() -> None:
         if "window_values" not in existing_columns:
             connection.exec_driver_sql(
                 "ALTER TABLE benefit ADD COLUMN window_values JSON"
+            )
+
+
+def ensure_benefit_window_tracking_column() -> None:
+    """Ensure benefits can override their window alignment."""
+
+    with engine.connect() as connection:
+        existing_columns = {
+            row[1] for row in connection.exec_driver_sql("PRAGMA table_info(benefit)")
+        }
+        if "window_tracking_mode" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE benefit ADD COLUMN window_tracking_mode VARCHAR"
             )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -71,6 +71,7 @@ class Benefit(SQLModel, table=True):
         default=None,
         sa_column=Column(JSON, nullable=True),
     )
+    window_tracking_mode: Optional[YearTrackingMode] = Field(default=None)
     expiration_date: Optional[date] = None
     is_used: bool = Field(default=False)
     used_at: Optional[datetime] = None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -58,6 +58,7 @@ class BenefitBase(SQLModel):
     expected_value: Optional[float] = Field(default=None, ge=0)
     expiration_date: Optional[date] = None
     window_values: Optional[List[float]] = None
+    window_tracking_mode: Optional[YearTrackingMode] = None
 
 
 class BenefitCreate(BenefitBase):
@@ -86,6 +87,7 @@ class BenefitUpdate(SQLModel):
     is_used: Optional[bool] = None
     expected_value: Optional[float] = Field(default=None, ge=0)
     window_values: Optional[List[float]] = None
+    window_tracking_mode: Optional[YearTrackingMode] = None
 
     @model_validator(mode="after")
     def validate_window_values(
@@ -399,6 +401,7 @@ class PreconfiguredBenefitBase(SQLModel):
     value: Optional[float] = Field(default=None, ge=0)
     expected_value: Optional[float] = Field(default=None, ge=0)
     window_values: Optional[List[float]] = None
+    window_tracking_mode: Optional[YearTrackingMode] = None
 
 
 class PreconfiguredBenefitCreate(PreconfiguredBenefitBase):

--- a/frontend/src/components/BenefitCard.vue
+++ b/frontend/src/components/BenefitCard.vue
@@ -117,7 +117,7 @@ const redemptionSummary = computed(() => {
   if (props.benefit.type === 'cumulative') {
     const used = props.benefit.cycle_redemption_total || 0
     if (props.benefit.expected_value != null) {
-      return `Recorded $${used.toFixed(2)} this cycle · Expected $${props.benefit.expected_value.toFixed(2)}`
+      return `Recorded $${used.toFixed(2)} this cycle · $${props.benefit.expected_value.toFixed(2)}`
     }
     return `Recorded $${used.toFixed(2)} this cycle`
   }
@@ -245,7 +245,7 @@ const annualRedeemed = computed(() => Number(props.benefit.cycle_redemption_tota
         </strong>
         <strong v-else>
           <template v-if="benefit.expected_value != null">
-            Expected ${{ Number(benefit.expected_value).toFixed(2) }}
+            ${{ Number(benefit.expected_value).toFixed(2) }}
           </template>
           <template v-else>
             ${{ benefit.cycle_redemption_total.toFixed(2) }}
@@ -254,7 +254,7 @@ const annualRedeemed = computed(() => Number(props.benefit.cycle_redemption_tota
       </div>
       <div class="benefit-actions">
         <button
-          v-if="benefit.type === 'standard'"
+          v-if="benefit.type === 'standard' && !benefit.is_used"
           class="primary-button"
           type="button"
           @click="emit('add-redemption', benefit)"
@@ -263,26 +263,13 @@ const annualRedeemed = computed(() => Number(props.benefit.cycle_redemption_tota
           Redeem
         </button>
         <button
-          v-if="benefit.type === 'standard'"
+          v-if="benefit.type !== 'standard'"
           class="primary-button secondary"
           type="button"
-          :aria-pressed="benefit.is_used"
-          title="Mark benefit as done"
-          @click="emit('toggle', !benefit.is_used)"
-        >
-          Done
-        </button>
-        <button
-          v-if="benefit.type !== 'standard'"
-          class="icon-button accent"
-          type="button"
           @click="emit('add-redemption', benefit)"
-          title="Add redemption"
+          title="Redeem benefit"
         >
-          <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path d="M10 4a1 1 0 0 1 1 1v4h4a1 1 0 1 1 0 2h-4v4a1 1 0 1 1-2 0v-4H5a1 1 0 1 1 0-2h4V5a1 1 0 0 1 1-1z" />
-          </svg>
-          <span class="sr-only">Add redemption</span>
+          Redeem
         </button>
         <button
           v-if="showHistoryButton"

--- a/frontend/src/utils/dates.js
+++ b/frontend/src/utils/dates.js
@@ -57,23 +57,25 @@ export function addMonths(date, count) {
   return makeDate(targetYear, monthIndex, instance.getDate())
 }
 
-export function computeCardCycle(card, referenceDate = new Date()) {
+export function computeCycleForMode(card, mode, referenceDate = new Date()) {
   const today = startOfDay(referenceDate)
-  const mode = card.year_tracking_mode || 'calendar'
-  if (mode === 'anniversary') {
-    const dueDate = parseDate(card.fee_due_date)
-    const dueMonth = dueDate.getMonth()
-    const dueDay = dueDate.getDate()
-    let cycleEnd = makeDate(today.getFullYear(), dueMonth, dueDay)
-    if (cycleEnd <= today) {
-      cycleEnd = makeDate(today.getFullYear() + 1, dueMonth, dueDay)
-    }
-    const cycleStart = makeDate(cycleEnd.getFullYear() - 1, dueMonth, dueDay)
-    return {
-      mode: 'anniversary',
-      start: cycleStart,
-      end: cycleEnd,
-      label: `${cycleStart.getFullYear()}-${cycleEnd.getFullYear()}`
+  const effectiveMode = mode || card?.year_tracking_mode || 'calendar'
+  if (effectiveMode === 'anniversary') {
+    const dueDate = parseDate(card?.fee_due_date)
+    if (dueDate) {
+      const dueMonth = dueDate.getMonth()
+      const dueDay = dueDate.getDate()
+      let cycleEnd = makeDate(today.getFullYear(), dueMonth, dueDay)
+      if (cycleEnd <= today) {
+        cycleEnd = makeDate(today.getFullYear() + 1, dueMonth, dueDay)
+      }
+      const cycleStart = makeDate(cycleEnd.getFullYear() - 1, dueMonth, dueDay)
+      return {
+        mode: 'anniversary',
+        start: cycleStart,
+        end: cycleEnd,
+        label: `${cycleStart.getFullYear()}-${cycleEnd.getFullYear()}`
+      }
     }
   }
   const year = today.getFullYear()
@@ -83,6 +85,15 @@ export function computeCardCycle(card, referenceDate = new Date()) {
     end: makeDate(year + 1, 0, 1),
     label: `${year}`
   }
+}
+
+export function computeCardCycle(card, referenceDate = new Date()) {
+  return computeCycleForMode(card, card?.year_tracking_mode || 'calendar', referenceDate)
+}
+
+export function computeBenefitCycle(card, benefit, referenceDate = new Date()) {
+  const mode = benefit?.window_tracking_mode || card?.year_tracking_mode || 'calendar'
+  return computeCycleForMode(card, mode, referenceDate)
 }
 
 export function buildCardCycles(card, earliestDate, referenceDate = new Date()) {


### PR DESCRIPTION
## Summary
* Backend now supports per-benefit window alignment via the new `window_tracking_mode` column and associated schema updates. `crud.py`, `main.py`, `database.py`, `models.py`, and `schemas.py` were touched; metrics gathering now respects per-benefit alignment.
* Standard benefit redemptions automatically toggle completion (`crud.py`), and the BenefitCard UI was simplified to a single Redeem button that disappears once used.
* Benefit alignment controls were added to both the card benefit modal and the admin preconfigured-benefit editor (`CreditCardCard.vue`, `App.vue`, `utils/dates.js`).
* “Expected” wording was removed from cumulative benefit displays (`BenefitCard.vue`), and all affected front-end modules were rebuilt successfully (`npm run build`).

## Testing
* npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d69b6bbd78832e901a81fe495d2f5c