### PR TITLE
Add redeem actions per window and adjust potential value

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1218,6 +1218,23 @@ textarea:focus {
   gap: 0.5rem;
 }
 
+.window-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.window-card__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.window-card__actions {
+  flex-shrink: 0;
+}
+
 .window-title {
   margin: 0;
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- add a redeem action to each recurring window in the benefit history modal with sensible defaults
- clamp redemption defaults and date selection to the chosen window context
- ignore expired benefit windows when computing credit card potential value totals

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6d45c10ec832e856b4dce586a883d