### PR TITLE
Highlight redeemed benefit windows and improve redemption modal

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1218,6 +1218,12 @@ textarea:focus {
   gap: 0.5rem;
 }
 
+.window-card--redeemed {
+  border-color: rgba(34, 197, 94, 0.5);
+  background: #ecfdf3;
+  box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.2);
+}
+
 .window-card__header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- highlight redeemed recurring windows for standard and incremental benefits
- ensure the redemption modal stacks above the benefit history modal
- default new redemption labels to the related benefit name

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6fbdf41e8832e96dd2b8cf355fd3c