### PR TITLE
Highlight expired benefit value in UI

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -121,6 +121,7 @@ class BenefitRead(BenefitBase):
     current_window_index: Optional[int] = Field(default=None, ge=1)
     cycle_window_count: Optional[int] = Field(default=None, ge=1)
     cycle_target_value: Optional[float] = Field(default=None, ge=0)
+    missed_window_value: float = Field(default=0, ge=0)
 
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
## Summary
- add a missed_window_value field to benefit responses and reuse it when computing totals
- surface expired standard and incremental credit amounts with red indicators in the benefit card
- extend the incremental progress bar to render a red segment for expired credits

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d730ae6c74832e9a9e28ad2fd6125e