### PR TITLE
Add benefit window exclusions and standard usage visuals

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -88,6 +88,18 @@ class BenefitRedemption(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
 
+class BenefitWindowExclusion(SQLModel, table=True):
+    """Windows that should be excluded from benefit calculations."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    benefit_id: int = Field(foreign_key="benefit.id", index=True)
+    window_start: date = Field(index=True)
+    window_end: date
+    window_label: Optional[str] = None
+    window_index: Optional[int] = Field(default=None, ge=1)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
 class NotificationSettings(SQLModel, table=True):
     """Connection settings for the Home Assistant notification webhook."""
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -104,6 +104,33 @@ class BenefitUsageUpdate(SQLModel):
     is_used: bool
 
 
+class BenefitWindowExclusionBase(SQLModel):
+    window_start: date
+    window_end: date
+    window_index: Optional[int] = Field(default=None, ge=1)
+    window_label: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_bounds(
+        cls, values: "BenefitWindowExclusionBase"
+    ) -> "BenefitWindowExclusionBase":  # type: ignore[name-defined]
+        if values.window_end <= values.window_start:
+            raise ValueError("Window end must be after the start date.")
+        return values
+
+
+class BenefitWindowExclusionCreate(BenefitWindowExclusionBase):
+    pass
+
+
+class BenefitWindowExclusionRead(BenefitWindowExclusionBase):
+    id: int
+    benefit_id: int
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class BenefitRead(BenefitBase):
     id: int
     credit_card_id: int
@@ -122,6 +149,8 @@ class BenefitRead(BenefitBase):
     cycle_window_count: Optional[int] = Field(default=None, ge=1)
     cycle_target_value: Optional[float] = Field(default=None, ge=0)
     missed_window_value: float = Field(default=0, ge=0)
+    active_window_indexes: List[int] = Field(default_factory=list)
+    window_exclusions: List[BenefitWindowExclusionRead] = Field(default_factory=list)
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1254,6 +1254,44 @@ textarea:focus {
   height: 0.95rem;
 }
 
+.window-deleted {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(226, 232, 240, 0.8);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.window-deleted__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.window-deleted__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.window-deleted__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.window-deleted__label {
+  flex: 1;
+}
+
 .window-title {
   margin: 0;
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- add backend support for benefit window exclusions with CRUD endpoints
- expose deleted window data to the frontend and allow deleting/restoring windows from the history modal
- refresh standard benefit cards with a progress bar and used/remaining/expired breakdown

## Testing
- npm run build
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7d8210aa0832e8c3582643dd6bc2f