### PR TITLE
Revamp benefit card usage styling

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2984,6 +2984,7 @@ onMounted(async () => {
   >
     <div v-if="historyModal.loading" class="history-loading">Loading history...</div>
     <template v-else>
+      <h3 class="history-section-title">History</h3>
       <p v-if="historyModal.windowLabel" class="history-window-label">
         Current window: {{ historyModal.windowLabel }}
       </p>
@@ -3141,13 +3142,6 @@ onMounted(async () => {
               </svg>
               <span class="sr-only">Delete window</span>
             </button>
-            <button
-              class="primary-button small"
-              type="button"
-              @click="handleRedeemWindow(window)"
-            >
-              Redeem
-            </button>
           </div>
         </div>
         <p class="window-total">Total used: <strong>${{ window.total.toFixed(2) }}</strong></p>
@@ -3161,6 +3155,11 @@ onMounted(async () => {
           </li>
         </ul>
         <p v-else class="history-benefit-empty">No activity recorded.</p>
+        <div class="window-card__footer">
+          <button class="primary-button small" type="button" @click="handleRedeemWindow(window)">
+            Redeem
+          </button>
+        </div>
       </article>
     </div>
     <div v-if="benefitWindowsModal.deletedWindows.length" class="window-deleted">

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1082,6 +1082,15 @@ textarea:focus {
   margin-bottom: 0.75rem;
 }
 
+.history-section-title {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #94a3b8;
+}
+
 .card-history-grid {
   display: flex;
   flex-direction: column;
@@ -1252,6 +1261,12 @@ textarea:focus {
 .window-card__actions .icon-button svg {
   width: 0.95rem;
   height: 0.95rem;
+}
+
+.window-card__footer {
+  margin-top: 0.25rem;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .window-deleted {


### PR DESCRIPTION
## Summary
- restyle benefit card usage bars and metrics across benefit types to match the updated design
- remove the "Worth $N this window" label and add a History heading in the redemption modal
- move the recurring window Redeem button to the card footer and add supporting styles
- ensure standard benefit usage metrics pull from annual cycle totals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d806477220832e954b8a9ff8f62036