### PR TITLE
Fix incremental benefit completion and expiration handling

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2374,7 +2374,7 @@ onMounted(async () => {
                 v-for="entry in benefitsCollection"
                 :key="entry.benefit.id"
                 :benefit="entry.benefit"
-                :card-context="{ name: entry.card.card_name, company: entry.card.company_name }"
+                :card-context="entry.card"
                 :show-edit="false"
                 @toggle="(value) => handleToggleBenefit({ id: entry.benefit.id, value })"
                 @delete="() => handleDeleteBenefit(entry.benefit.id)"

--- a/frontend/src/components/CreditCardCard.vue
+++ b/frontend/src/components/CreditCardCard.vue
@@ -567,6 +567,7 @@ function handleCardDelete() {
             v-for="benefit in sortedBenefits"
             :key="benefit.id"
             :benefit="benefit"
+            :card-context="card"
             @toggle="(value) => emit('toggle-benefit', { id: benefit.id, value })"
             @delete="emit('delete-benefit', benefit.id)"
             @add-redemption="emit('add-redemption', { card, benefit })"

--- a/frontend/src/utils/benefits.js
+++ b/frontend/src/utils/benefits.js
@@ -19,8 +19,22 @@ export function isBenefitCompleted(benefit) {
     return Boolean(benefit.is_used)
   }
   if (benefit.type === 'incremental') {
-    const target = Number(benefit.cycle_target_value ?? benefit.value ?? 0)
-    const used = Number(benefit.cycle_redemption_total ?? 0)
+    const targetCandidates = [
+      benefit.current_window_value,
+      benefit.cycle_target_value,
+      benefit.value
+    ]
+    let target = 0
+    for (const candidate of targetCandidates) {
+      const parsed = Number(candidate)
+      if (Number.isFinite(parsed) && parsed > 0) {
+        target = parsed
+        break
+      }
+    }
+    const used = Number(
+      benefit.current_window_total ?? benefit.cycle_redemption_total ?? 0
+    )
     return target > 0 && used >= target
   }
   if (benefit.type === 'cumulative') {


### PR DESCRIPTION
## Summary
- ensure incremental benefits are considered complete when the current window total meets the window target so sorting moves them with other completed items
- show calendar-aligned benefit expirations on the last day of their window and provide card context for consistent tracking mode detection

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d8136e14f0832ea64ab199cd90dfa9