### PR TITLE
Add template export workflow and cancelled card reminders

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -72,6 +72,7 @@ def _run_database_initialisation_steps() -> None:
     ensure_benefit_window_tracking_column()
     ensure_benefit_visibility_column()
     ensure_card_year_tracking_column()
+    ensure_card_cancelled_column()
 
 
 @contextmanager
@@ -233,6 +234,19 @@ def ensure_card_year_tracking_column() -> None:
         if "year_tracking_mode" not in existing_columns:
             connection.exec_driver_sql(
                 "ALTER TABLE creditcard ADD COLUMN year_tracking_mode VARCHAR NOT NULL DEFAULT 'calendar'"
+            )
+
+
+def ensure_card_cancelled_column() -> None:
+    """Ensure credit cards track whether they have been cancelled."""
+
+    with engine.connect() as connection:
+        existing_columns = {
+            row[1] for row in connection.exec_driver_sql("PRAGMA table_info(creditcard)")
+        }
+        if "is_cancelled" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE creditcard ADD COLUMN is_cancelled BOOLEAN NOT NULL DEFAULT 0"
             )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -54,6 +54,10 @@ class CreditCard(SQLModel, table=True):
         default=YearTrackingMode.calendar,
         description="How the card's history windows are calculated",
     )
+    is_cancelled: bool = Field(
+        default=False,
+        description="Whether the card has been cancelled and should trigger reminders",
+    )
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
 class Benefit(SQLModel, table=True):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -189,6 +189,7 @@ class CreditCardBase(SQLModel):
     annual_fee: float = Field(ge=0)
     fee_due_date: date
     year_tracking_mode: YearTrackingMode = Field(default=YearTrackingMode.calendar)
+    is_cancelled: bool = Field(default=False)
 
 
 class CreditCardCreate(CreditCardBase):
@@ -203,6 +204,7 @@ class CreditCardUpdate(SQLModel):
     annual_fee: Optional[float] = Field(default=None, ge=0)
     fee_due_date: Optional[date] = None
     year_tracking_mode: Optional[YearTrackingMode] = None
+    is_cancelled: Optional[bool] = None
 
 
 class CreditCardRead(CreditCardBase):
@@ -399,15 +401,27 @@ class NotificationDailyTestRequest(SQLModel):
 
 
 class NotificationBenefitSummary(SQLModel):
+    summary_type: str = Field(default="benefit")
     card_name: str
     benefit_name: str
     expiration_date: date
 
 
+class NotificationCancelledCardSummary(SQLModel):
+    summary_type: str = Field(default="cancelled_card")
+    card_name: str
+    account_name: Optional[str] = None
+    company_name: Optional[str] = None
+    fee_due_date: date
+    days_until_due: int
+
+
 class NotificationDispatchResult(SQLModel):
     sent: bool
     message: Optional[str] = None
-    categories: Dict[str, List[NotificationBenefitSummary]] = Field(default_factory=dict)
+    categories: Dict[
+        str, List[NotificationBenefitSummary | NotificationCancelledCardSummary]
+    ] = Field(default_factory=dict)
     target: Optional[str] = None
 
 
@@ -476,4 +490,13 @@ class PreconfiguredCardRead(SQLModel):
     company_name: str
     annual_fee: float = Field(ge=0)
     benefits: List[PreconfiguredBenefitRead]
+
+
+class CardTemplateExportRequest(SQLModel):
+    slug: Optional[str] = None
+    card_type: Optional[str] = None
+    company_name: Optional[str] = None
+    annual_fee: Optional[float] = Field(default=None, ge=0)
+    override_existing: bool = Field(default=False)
+    override_slug: Optional[str] = None
 

--- a/frontend/src/components/CreditCardCard.vue
+++ b/frontend/src/components/CreditCardCard.vue
@@ -26,7 +26,8 @@ const emit = defineEmits([
   'update-benefit',
   'edit-card',
   'view-card-history',
-  'view-benefit-windows'
+  'view-benefit-windows',
+  'export-template'
 ])
 
 const benefitModalOpen = ref(false)
@@ -491,6 +492,10 @@ function handleCardEdit() {
 function handleCardDelete() {
   emit('delete-card', props.card.id)
 }
+
+function handleCardExport() {
+  emit('export-template', props.card)
+}
 </script>
 
 <template>
@@ -504,7 +509,10 @@ function handleCardDelete() {
           <span>•</span>
           <span>{{ card.account_name }}</span>
         </div>
-        <div class="card-due">Fee due {{ new Date(card.fee_due_date).toLocaleDateString() }}</div>
+        <div class="card-due">
+          Fee due {{ new Date(card.fee_due_date).toLocaleDateString() }}
+          <span v-if="card.is_cancelled" class="card-status card-status--cancelled">Cancelled</span>
+        </div>
       </div>
       <div class="card-header__meta">
         <div class="card-cycle">
@@ -524,6 +532,13 @@ function handleCardDelete() {
               <path d="M15.58 2.42a1.5 1.5 0 0 0-2.12 0l-9 9V17h5.59l9-9a1.5 1.5 0 0 0 0-2.12zM7 15H5v-2l6.88-6.88 2 2z" />
             </svg>
             <span class="sr-only">Edit card</span>
+          </button>
+          <button class="icon-button ghost" type="button" @click="handleCardExport" title="Export as template">
+            <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+              <rect x="6" y="5" width="9" height="11" rx="1.6" />
+              <path d="M4 11V6.6A1.6 1.6 0 0 1 5.6 5H11" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+            <span class="sr-only">Export as template</span>
           </button>
           <button class="icon-button danger" type="button" @click="handleCardDelete" title="Remove card">
             <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -703,6 +718,25 @@ function handleCardDelete() {
 .card-due {
   font-size: 0.85rem;
   color: #64748b;
+}
+
+.card-status {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+}
+
+.card-status--cancelled {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+  border-color: rgba(239, 68, 68, 0.32);
 }
 
 .card-header__meta {

--- a/frontend/src/components/CreditCardList.vue
+++ b/frontend/src/components/CreditCardList.vue
@@ -22,7 +22,8 @@ const emit = defineEmits([
   'update-benefit',
   'edit-card',
   'view-card-history',
-  'view-benefit-windows'
+  'view-benefit-windows',
+  'export-template'
 ])
 </script>
 
@@ -43,6 +44,7 @@ const emit = defineEmits([
       @edit-card="emit('edit-card', $event)"
       @view-card-history="emit('view-card-history', $event)"
       @view-benefit-windows="emit('view-benefit-windows', $event)"
+      @export-template="emit('export-template', $event)"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- add an `is_cancelled` flag to cards with database migration and include it in card responses
- expand daily notification logic to remind about cancelled cards approaching annual fee due dates and surface the new category in the UI
- add an API endpoint and Vue workflow to export a card (with optional override) as a reusable template and expose a cancel card toggle in the edit modal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d82ba613a8832e892f0b658b1cf85b