### PR TITLE
Preserve scroll on dashboard updates and correct benefit expiration

### DIFF
--- a/frontend/src/components/BenefitCard.vue
+++ b/frontend/src/components/BenefitCard.vue
@@ -149,12 +149,18 @@ const incrementalProgress = computed(() => {
     ? Math.min((expired / target) * 100, Math.max(100 - usedPercent, 0))
     : 0
   const remaining = Math.max(target - used - expired, 0)
+  const remainingPercent = target > 0
+    ? Math.max(100 - usedPercent - expiredPercent, 0)
+    : 0
   const statusText = target <= 0
     ? `${used > 0 ? `$${used.toFixed(2)} logged` : 'No goal set'}`
     : remaining <= 0
       ? 'Complete'
       : `$${remaining.toFixed(2)} remaining`
   const accessibleParts = [`Used $${used.toFixed(2)} of $${target.toFixed(2)}`]
+  if (remaining > 0) {
+    accessibleParts.push(`Remaining $${remaining.toFixed(2)}`)
+  }
   if (expired > 0) {
     accessibleParts.push(`Expired $${expired.toFixed(2)}`)
   }
@@ -163,6 +169,7 @@ const incrementalProgress = computed(() => {
     target,
     remaining,
     usedPercent,
+    remainingPercent,
     expiredPercent,
     expired,
     statusText,
@@ -332,6 +339,12 @@ const standardUsage = computed(() => {
             <div
               class="benefit-progress-chart__segment benefit-progress-chart__segment--used"
               :style="{ width: `${incrementalProgress.usedPercent}%` }"
+              aria-hidden="true"
+            ></div>
+            <div
+              v-if="incrementalProgress.remainingPercent > 0"
+              class="benefit-progress-chart__segment benefit-progress-chart__segment--remaining"
+              :style="{ width: `${incrementalProgress.remainingPercent}%` }"
               aria-hidden="true"
             ></div>
             <div


### PR DESCRIPTION
## Summary
- preserve the dashboard scroll position when card data refreshes by tracking view-specific scroll offsets
- update the incremental benefit progress bar so the remaining portion appears between redeemed and expired values
- recompute benefit expiration dates when a window tracking override is set to keep calendar-aligned benefits from showing AF-based expirations

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d830b2fcdc832e89086b9989031282