### PR TITLE
Add search filtering to benefits page

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1159,6 +1159,8 @@ const totals = computed(() => {
   }
 })
 
+const benefitSearchQuery = ref('')
+
 const benefitsCollection = computed(() => {
   const entries = []
   for (const card of cards.value) {
@@ -1173,6 +1175,19 @@ const benefitsCollection = computed(() => {
     }
   }
   return entries.sort((a, b) => compareBenefits(a.benefit, b.benefit))
+})
+
+const filteredBenefitsCollection = computed(() => {
+  const query = benefitSearchQuery.value.trim().toLowerCase()
+  if (!query) {
+    return benefitsCollection.value
+  }
+  return benefitsCollection.value.filter(({ benefit }) => {
+    const name = typeof benefit?.name === 'string' ? benefit.name.toLowerCase() : ''
+    const description =
+      typeof benefit?.description === 'string' ? benefit.description.toLowerCase() : ''
+    return name.includes(query) || description.includes(query)
+  })
 })
 
 async function loadFrequencies() {
@@ -2640,19 +2655,34 @@ onMounted(async () => {
                   Review every benefit across your cards in a single view.
                 </p>
               </div>
+              <div class="section-actions">
+                <input
+                  v-model="benefitSearchQuery"
+                  type="search"
+                  class="section-search-input"
+                  placeholder="Search benefits"
+                  aria-label="Search benefits"
+                />
+              </div>
             </div>
             <p v-if="loading" class="empty-state">Loading benefits...</p>
             <p v-else-if="!benefitsCollection.length" class="empty-state">
               No benefits to display yet. Add benefits to your cards to see them here.
             </p>
+            <p
+              v-else-if="benefitsCollection.length && !filteredBenefitsCollection.length"
+              class="empty-state"
+            >
+              No benefits match your search.
+            </p>
           </div>
           <div
-            v-if="!loading && benefitsCollection.length"
+            v-if="!loading && filteredBenefitsCollection.length"
             class="benefits-collection content-constrained"
           >
             <div class="benefits-collection-grid">
               <BenefitCard
-                v-for="entry in benefitsCollection"
+                v-for="entry in filteredBenefitsCollection"
                 :key="entry.benefit.id"
                 :benefit="entry.benefit"
                 :card-context="entry.card"

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1015,6 +1015,10 @@ textarea:focus {
   flex-wrap: wrap;
 }
 
+.section-search-input {
+  min-width: min(20rem, 100%);
+}
+
 .section-header .section-title {
   margin-bottom: 0;
 }


### PR DESCRIPTION
## Summary
- add a search box to the benefits view and store the query in component state
- filter the benefits collection by name and description and show an empty-state message for no matches
- add styling so the search input fits within the section header layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d98056a354832ea46ceb2c85f5c2be