### PR TITLE
Compute deleted window flag from window exclusions

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -193,6 +193,7 @@ class BenefitRead(BenefitBase):
     missed_window_value: float = Field(default=0, ge=0)
     active_window_indexes: List[int] = Field(default_factory=list)
     window_exclusions: List[BenefitWindowExclusionRead] = Field(default_factory=list)
+    current_window_deleted: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -790,10 +790,26 @@ textarea {
   opacity: 0.95;
 }
 
+.benefit-card.window-deleted {
+  border-color: rgba(148, 163, 184, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+  background: #f8fafc;
+  opacity: 0.72;
+}
+
+.benefit-card.window-deleted .benefit-name,
+.benefit-card.window-deleted .benefit-amount,
+.benefit-card.window-deleted .benefit-used {
+  color: #64748b;
+}
+
 .benefit-header {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  row-gap: 0.75rem;
 }
 
 .benefit-name {

--- a/frontend/src/utils/benefits.js
+++ b/frontend/src/utils/benefits.js
@@ -49,6 +49,11 @@ export function isBenefitCompleted(benefit) {
 }
 
 export function compareBenefits(a, b) {
+  const deletedA = Boolean(a?.current_window_deleted)
+  const deletedB = Boolean(b?.current_window_deleted)
+  if (deletedA !== deletedB) {
+    return deletedA ? 1 : -1
+  }
   const completedA = isBenefitCompleted(a)
   const completedB = isBenefitCompleted(b)
   if (completedA !== completedB) {


### PR DESCRIPTION
## Summary
- derive the deleted-window state at request time using today's date and the recorded window exclusions
- keep the benefit metric context lightweight by sharing the reference date instead of persisting a deleted flag

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dc9ace71c0832e9ff78356d08e0f6a