### PR TITLE
Add notification exclusion toggle for benefits

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -74,6 +74,7 @@ def _run_database_initialisation_steps() -> None:
     ensure_benefit_window_values_column()
     ensure_benefit_window_tracking_column()
     ensure_benefit_visibility_column()
+    ensure_benefit_notification_column()
     ensure_card_year_tracking_column()
     ensure_card_cancelled_column()
 
@@ -224,6 +225,19 @@ def ensure_benefit_visibility_column() -> None:
         if "exclude_from_benefits_page" not in existing_columns:
             connection.exec_driver_sql(
                 "ALTER TABLE benefit ADD COLUMN exclude_from_benefits_page BOOLEAN NOT NULL DEFAULT 0"
+            )
+
+
+def ensure_benefit_notification_column() -> None:
+    """Ensure benefits can be excluded from notification reminders."""
+
+    with engine.connect() as connection:
+        existing_columns = {
+            row[1] for row in connection.exec_driver_sql("PRAGMA table_info(benefit)")
+        }
+        if "exclude_from_notifications" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE benefit ADD COLUMN exclude_from_notifications BOOLEAN NOT NULL DEFAULT 0"
             )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -565,6 +565,7 @@ def export_card_template(
             "frequency": benefit.frequency,
             "type": benefit.type,
             "exclude_from_benefits_page": benefit.exclude_from_benefits_page,
+            "exclude_from_notifications": benefit.exclude_from_notifications,
         }
         if benefit.type == BenefitType.cumulative:
             if benefit.expected_value is not None:
@@ -1481,6 +1482,7 @@ def build_benefit_read(
         is_used=benefit.is_used,
         used_at=benefit.used_at,
         exclude_from_benefits_page=benefit.exclude_from_benefits_page,
+        exclude_from_notifications=benefit.exclude_from_notifications,
         redemption_total=total,
         redemption_count=count,
         remaining_value=remaining,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -83,6 +83,10 @@ class Benefit(SQLModel, table=True):
         default=False,
         description="Whether the benefit should be hidden from the aggregated benefits page",
     )
+    exclude_from_notifications: bool = Field(
+        default=False,
+        description="Whether the benefit should be excluded from notification digests",
+    )
 
 
 class BenefitRedemption(SQLModel, table=True):

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -177,6 +177,7 @@ class NotificationService:
             .join(CreditCard, CreditCard.id == Benefit.credit_card_id)
             .where(Benefit.expiration_date.is_not(None))
             .where(Benefit.type != BenefitType.cumulative)
+            .where(Benefit.exclude_from_notifications.is_(False))
             .where(Benefit.expiration_date >= start)
             .where(Benefit.expiration_date <= end)
             .order_by(Benefit.expiration_date, CreditCard.card_name, Benefit.name)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -100,6 +100,7 @@ class BenefitBase(SQLModel):
     window_values: Optional[List[float]] = None
     window_tracking_mode: Optional[YearTrackingMode] = None
     exclude_from_benefits_page: bool = Field(default=False)
+    exclude_from_notifications: bool = Field(default=False)
 
 
 class BenefitCreate(BenefitBase):
@@ -130,6 +131,7 @@ class BenefitUpdate(SQLModel):
     window_values: Optional[List[float]] = None
     window_tracking_mode: Optional[YearTrackingMode] = None
     exclude_from_benefits_page: Optional[bool] = None
+    exclude_from_notifications: Optional[bool] = None
 
     @model_validator(mode="after")
     def validate_window_values(
@@ -490,6 +492,7 @@ class PreconfiguredBenefitBase(SQLModel):
     window_values: Optional[List[float]] = None
     window_tracking_mode: Optional[YearTrackingMode] = None
     exclude_from_benefits_page: bool = Field(default=False)
+    exclude_from_notifications: bool = Field(default=False)
 
 
 class PreconfiguredBenefitCreate(PreconfiguredBenefitBase):

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -886,7 +886,8 @@ function normaliseCard(card) {
   if (Array.isArray(card.benefits)) {
     normalized.benefits = card.benefits.map((benefit) => ({
       ...benefit,
-      exclude_from_benefits_page: Boolean(benefit.exclude_from_benefits_page)
+      exclude_from_benefits_page: Boolean(benefit.exclude_from_benefits_page),
+      exclude_from_notifications: Boolean(benefit.exclude_from_notifications)
     }))
   }
   return normalized
@@ -919,6 +920,7 @@ function createAdminBenefit(overrides = {}) {
     window_values: [],
     window_tracking_mode: '',
     exclude_from_benefits_page: false,
+    exclude_from_notifications: false,
     ...overrides
   }
 }
@@ -1397,7 +1399,8 @@ function openAdminEditModal(card) {
         ? benefit.window_values.map((value) => value.toString())
         : [],
       window_tracking_mode: benefit.window_tracking_mode || '',
-      exclude_from_benefits_page: Boolean(benefit.exclude_from_benefits_page)
+      exclude_from_benefits_page: Boolean(benefit.exclude_from_benefits_page),
+      exclude_from_notifications: Boolean(benefit.exclude_from_notifications)
     })
   )
   if (!adminModal.form.benefits.length) {
@@ -1496,6 +1499,9 @@ async function submitAdminCard() {
         base.exclude_from_benefits_page = Boolean(
           benefit.exclude_from_benefits_page
         )
+        base.exclude_from_notifications = Boolean(
+          benefit.exclude_from_notifications
+        )
         return base
       })
     }
@@ -1565,6 +1571,9 @@ async function handleCreateCard() {
         }
         if (benefit.exclude_from_benefits_page) {
           benefitPayload.exclude_from_benefits_page = true
+        }
+        if (benefit.exclude_from_notifications) {
+          benefitPayload.exclude_from_notifications = true
         }
         if (benefit.type === 'cumulative') {
           if (benefit.expected_value != null) {
@@ -3703,6 +3712,10 @@ onMounted(async () => {
           <label class="checkbox-option admin-benefit-exclude">
             <input v-model="benefit.exclude_from_benefits_page" type="checkbox" />
             <span>Hide from benefits overview</span>
+          </label>
+          <label class="checkbox-option admin-benefit-exclude">
+            <input v-model="benefit.exclude_from_notifications" type="checkbox" />
+            <span>Exclude from notifications</span>
           </label>
           <p class="helper-text">{{ benefitTypeDescriptions[benefit.type] }}</p>
           <div class="admin-benefit-card__footer">

--- a/frontend/src/components/BenefitCard.vue
+++ b/frontend/src/components/BenefitCard.vue
@@ -518,7 +518,7 @@ const showUsedValue = computed(() => {
     <footer class="benefit-footer">
       <div class="benefit-footer__values">
         <strong v-if="benefit.type !== 'cumulative'" class="benefit-amount">
-          Remaining ${{ remainingValueLabel }}
+          ${{ remainingValueLabel }}
         </strong>
         <strong v-else class="benefit-amount">
           <template v-if="benefit.expected_value != null">

--- a/frontend/src/components/CreditCardCard.vue
+++ b/frontend/src/components/CreditCardCard.vue
@@ -60,7 +60,8 @@ const form = reactive({
   windowTrackingMode: null,
   useCustomValues: false,
   window_values: [],
-  excludeFromBenefitsPage: false
+  excludeFromBenefitsPage: false,
+  excludeFromNotifications: false
 })
 
 const typeDescriptions = {
@@ -338,6 +339,7 @@ function resetForm() {
   form.useCustomValues = false
   form.window_values = []
   form.excludeFromBenefitsPage = false
+  form.excludeFromNotifications = false
   autoExpiration.value = true
   applyFrequencyDefaults()
 }
@@ -376,6 +378,7 @@ function populateForm(benefit) {
     ? benefit.window_values.map((value) => value.toString())
     : []
   form.excludeFromBenefitsPage = Boolean(benefit.exclude_from_benefits_page)
+  form.excludeFromNotifications = Boolean(benefit.exclude_from_notifications)
   if (benefit.frequency === 'yearly' && benefit.expiration_date) {
     const expirationDate = new Date(`${benefit.expiration_date}T00:00:00`)
     const cycleAtExpiration = computeCardCycle(props.card, expirationDate)
@@ -458,6 +461,7 @@ function submitForm() {
     }
   }
   payload.exclude_from_benefits_page = form.excludeFromBenefitsPage
+  payload.exclude_from_notifications = form.excludeFromNotifications
   if (formMode.value === 'edit' && editingBenefitId.value) {
     emit('update-benefit', {
       cardId: props.card.id,
@@ -679,6 +683,10 @@ function handleCardExport() {
         <label class="checkbox-option">
           <input v-model="form.excludeFromBenefitsPage" type="checkbox" />
           <span>Hide from benefits overview</span>
+        </label>
+        <label class="checkbox-option">
+          <input v-model="form.excludeFromNotifications" type="checkbox" />
+          <span>Exclude from notifications</span>
         </label>
         <p class="helper-text">{{ currentTypeDescription }}</p>
         <div class="modal-actions">


### PR DESCRIPTION
## Summary
- add a backend flag and migration helper to skip selected benefits from notifications
- expose an "Exclude from notifications" checkbox in card and template benefit editors and carry the value through exports
- tidy the benefit cards by removing the "Remaining" prefix from the remaining amount badge

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd0a4916b8832eb43286143b75bc79