### PR TITLE
Add drag-and-drop sorting for credit cards

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -58,6 +58,12 @@ class CreditCard(SQLModel, table=True):
         default=False,
         description="Whether the card has been cancelled and should trigger reminders",
     )
+    display_order: Optional[int] = Field(
+        default=None,
+        index=True,
+        description="Order used when presenting cards in the dashboard",
+        ge=0,
+    )
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
 class Benefit(SQLModel, table=True):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -253,6 +253,7 @@ class CreditCardUpdate(SQLModel):
 class CreditCardRead(CreditCardBase):
     id: int
     created_at: datetime
+    display_order: Optional[int] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -264,6 +265,16 @@ class CreditCardWithBenefits(CreditCardRead):
     net_position: float
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class CreditCardReorderRequest(SQLModel):
+    card_ids: List[int] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_unique_ids(self) -> "CreditCardReorderRequest":
+        if len(self.card_ids) != len(set(self.card_ids)):
+            raise ValueError("Card order cannot contain duplicates.")
+        return self
 
 
 class NotificationSettingsBase(SQLModel):

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1055,6 +1055,72 @@ textarea:focus {
   margin-top: 1rem;
 }
 
+.card-sort-list {
+  list-style: none;
+  margin: 1.25rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card-sort-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.9);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.06);
+  cursor: grab;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.card-sort-item:active {
+  cursor: grabbing;
+}
+
+.card-sort-item.is-active {
+  opacity: 0.92;
+  transform: scale(0.995);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.18);
+}
+
+.card-sort-item.is-over {
+  border-color: rgba(99, 102, 241, 0.55);
+  background: rgba(224, 231, 255, 0.6);
+}
+
+.card-sort-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  color: #6366f1;
+}
+
+.card-sort-handle svg {
+  width: 100%;
+  height: 100%;
+}
+
+.card-sort-index {
+  min-width: 1.75rem;
+  text-align: center;
+  font-weight: 600;
+  color: #475569;
+}
+
+.card-sort-name {
+  flex: 1;
+  font-weight: 500;
+  color: #0f172a;
+  word-break: break-word;
+}
+
 .primary-button.small {
   padding: 0.4rem 0.85rem;
   font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- add a persistent `display_order` to credit cards and migrate existing rows
- expose an API endpoint to save reordered card ids and honour the new order when listing cards
- add a dashboard “Sort cards” modal with drag-and-drop reordering and styling updates

## Testing
- npm run build
- python -m compileall app


------
https://chatgpt.com/codex/tasks/task_e_68dd22a70e1c832e8b52a7aaec0b583d