### PR TITLE
Add notification preferences and searchable history

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -12,6 +12,7 @@ from sqlalchemy import inspect
 from sqlalchemy.exc import OperationalError
 from sqlmodel import Session, SQLModel, create_engine
 
+from .migrations import run_migrations
 from .models import Bug
 
 logger = logging.getLogger("creditwatch.database")
@@ -68,6 +69,7 @@ def _run_database_initialisation_steps() -> None:
     except (OperationalError, sqlite3.OperationalError) as exc:
         _log_database_diagnostics(exc)
         raise
+    run_migrations(engine)
     ensure_bug_table()
     ensure_company_name_column()
     ensure_benefit_type_column()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ import sqlite3
 import tempfile
 from datetime import date, datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Literal, Optional, Sequence, Tuple
 
 from fastapi import (
     Depends,
@@ -323,9 +323,16 @@ async def trigger_daily_notification_test(
 )
 def get_notification_history_endpoint(
     limit: int = Query(50, ge=1, le=200),
+    sort_direction: Literal["asc", "desc"] = Query("desc"),
+    search: Optional[str] = Query(None, min_length=1, max_length=200),
     session: Session = Depends(get_session),
 ) -> List[NotificationLogRead]:
-    records = crud.list_notification_logs(session, limit=limit)
+    records = crud.list_notification_logs(
+        session,
+        limit=limit,
+        search=search.strip() if isinstance(search, str) else None,
+        sort_direction=sort_direction,
+    )
     return [
         NotificationLogRead.model_validate(record, from_attributes=True)
         for record in records

--- a/backend/app/migrations.py
+++ b/backend/app/migrations.py
@@ -1,0 +1,102 @@
+"""Lightweight database migration runner."""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Iterable, List, Sequence
+
+from sqlalchemy.engine import Connection, Engine
+
+logger = logging.getLogger("creditwatch.migrations")
+
+
+MigrationFunc = Callable[[Connection], None]
+
+
+def _ensure_migrations_table(connection: Connection) -> None:
+    """Create the schema migrations tracking table if required."""
+
+    connection.exec_driver_sql(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            name TEXT PRIMARY KEY,
+            applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+
+def _get_applied_migrations(connection: Connection) -> set[str]:
+    """Return the set of migration identifiers that have already run."""
+
+    rows = connection.exec_driver_sql("SELECT name FROM schema_migrations")
+    return {str(row[0]) for row in rows}
+
+
+def _record_migration(connection: Connection, name: str) -> None:
+    """Mark a migration as applied in the tracking table."""
+
+    connection.exec_driver_sql(
+        "INSERT INTO schema_migrations (name) VALUES (?)",
+        (name,),
+    )
+
+
+def _add_notification_reason_and_preferences(connection: Connection) -> None:
+    """Add audit fields for notification history and preferences."""
+
+    existing_log_columns = {
+        row[1]
+        for row in connection.exec_driver_sql("PRAGMA table_info(notificationlog)")
+    }
+    if "reason" not in existing_log_columns:
+        logger.info("Adding notificationlog.reason column")
+        connection.exec_driver_sql(
+            "ALTER TABLE notificationlog ADD COLUMN reason VARCHAR"
+        )
+
+    existing_settings_columns = {
+        row[1]
+        for row in connection.exec_driver_sql("PRAGMA table_info(notificationsettings)")
+    }
+    if "event_type_preferences" not in existing_settings_columns:
+        logger.info("Adding notificationsettings.event_type_preferences column")
+        connection.exec_driver_sql(
+            """
+            ALTER TABLE notificationsettings
+            ADD COLUMN event_type_preferences JSON NOT NULL DEFAULT '{}'
+            """
+        )
+        connection.exec_driver_sql(
+            """
+            UPDATE notificationsettings
+            SET event_type_preferences='{}'
+            WHERE event_type_preferences IS NULL
+            """
+        )
+
+
+MIGRATIONS: Sequence[tuple[str, MigrationFunc]] = (
+    ("2024100301_add_notification_reason_and_preferences", _add_notification_reason_and_preferences),
+)
+
+
+def run_migrations(engine: Engine) -> None:
+    """Apply outstanding migrations in order."""
+
+    if not MIGRATIONS:
+        return
+
+    with engine.begin() as connection:
+        _ensure_migrations_table(connection)
+        applied = _get_applied_migrations(connection)
+
+    for name, migration in MIGRATIONS:
+        if name in applied:
+            continue
+        logger.info("Applying migration %s", name)
+        with engine.begin() as connection:
+            migration(connection)
+            _record_migration(connection, name)
+        applied.add(name)
+

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -133,6 +133,14 @@ class NotificationSettings(SQLModel, table=True):
         description="Optional default target slug understood by the Home Assistant automation",
     )
     enabled: bool = Field(default=True, description="Whether notifications are currently enabled")
+    event_type_preferences: Dict[str, bool] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False, default=dict),
+        description=(
+            "Per-notification-type enablement overrides stored as a JSON mapping "
+            "of event type to boolean."
+        ),
+    )
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
@@ -171,6 +179,10 @@ class NotificationLog(SQLModel, table=True):
     sent: bool = Field(default=False, description="Whether the webhook call was successful")
     response_message: Optional[str] = Field(
         default=None, description="Human readable outcome message from the dispatcher"
+    )
+    reason: Optional[str] = Field(
+        default=None,
+        description="Explanation of why the notification ran or was skipped",
     )
     categories: Dict[str, object] = Field(
         default_factory=dict,

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -892,6 +892,52 @@ textarea {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
+.notification-history-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.notification-history-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.notification-history-search {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.notification-history-search input[type='search'] {
+  flex: 1 1 220px;
+  min-width: 200px;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  border-radius: 999px;
+  font-size: 0.9rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.notification-history-search input[type='search']:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.notification-history-search input[type='search']:disabled {
+  background: rgba(226, 232, 240, 0.4);
+  cursor: not-allowed;
+}
+
+.notification-history-toolbar .link-button {
+  white-space: nowrap;
+}
+
 .notification-history-table {
   width: 100%;
   border-collapse: collapse;
@@ -913,6 +959,12 @@ textarea {
   letter-spacing: 0.08em;
   color: #64748b;
   background: rgba(248, 250, 252, 0.8);
+}
+
+.notification-history-table td:nth-child(6),
+.notification-history-table td:nth-child(7) {
+  max-width: 14rem;
+  word-break: break-word;
 }
 
 .notification-history-table tbody tr:last-child td {
@@ -937,6 +989,43 @@ textarea {
 .status-pill.error {
   background: rgba(248, 113, 113, 0.18);
   color: #b91c1c;
+}
+
+.notification-type-settings {
+  margin-top: 1rem;
+}
+
+.notification-type-settings .field-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 0.35rem;
+}
+
+.notification-type-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.notification-type-option {
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.notification-type-option input[type='checkbox'] {
+  margin-top: 0.25rem;
+}
+
+.notification-type-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.notification-type-label {
+  font-weight: 600;
+  color: #0f172a;
 }
 
 .primary-button {


### PR DESCRIPTION
## Summary
- add a lightweight migration runner to persist notification reasons and type preferences
- extend notification services to honour per-type toggles and log reasons for each event
- enhance the admin UI with notification-type controls plus searchable, sortable history

## Testing
- python -m compileall backend/app
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68dd32f5118c832eba2b13e9d604091b