### PR TITLE
Add persistent theme toggle and interface settings

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -16,6 +16,7 @@ from .models import (
     BenefitWindowExclusion,
     Bug,
     CreditCard,
+    InterfaceSettings,
     NotificationLog,
     NotificationSettings,
     YearTrackingMode,
@@ -31,6 +32,7 @@ from .schemas import (
     BugUpdate,
     CreditCardCreate,
     CreditCardUpdate,
+    InterfaceSettingsUpdate,
     BackupSettingsUpdate,
     BackupSettingsWrite,
     NotificationSettingsUpdate,
@@ -315,6 +317,29 @@ def update_bug(session: Session, bug: Bug, payload: BugUpdate) -> Bug:
 def delete_bug(session: Session, bug: Bug) -> None:
     session.delete(bug)
     session.commit()
+
+
+def get_interface_settings(session: Session) -> InterfaceSettings:
+    settings = session.get(InterfaceSettings, 1)
+    if settings is None:
+        settings = InterfaceSettings(id=1)
+        session.add(settings)
+        session.commit()
+        session.refresh(settings)
+    return settings
+
+
+def update_interface_settings(
+    session: Session, payload: InterfaceSettingsUpdate
+) -> InterfaceSettings:
+    settings = get_interface_settings(session)
+    update_data = payload.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(settings, key, value)
+    session.add(settings)
+    session.commit()
+    session.refresh(settings)
+    return settings
 
 
 def delete_benefit_window_exclusion(

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import OperationalError
 from sqlmodel import Session, SQLModel, create_engine
 
 from .migrations import run_migrations
-from .models import Bug
+from .models import Bug, InterfaceSettings
 
 logger = logging.getLogger("creditwatch.database")
 
@@ -81,6 +81,7 @@ def _run_database_initialisation_steps() -> None:
     ensure_card_cancelled_column()
     ensure_card_cancelled_timestamp_column()
     ensure_card_display_order_column()
+    ensure_interface_settings_row()
 
 
 @contextmanager
@@ -305,6 +306,17 @@ def ensure_card_display_order_column() -> None:
                 (index, card_id),
             )
         connection.commit()
+
+
+def ensure_interface_settings_row() -> None:
+    """Ensure the interface settings table exists with a default record."""
+
+    with Session(engine) as session:
+        settings = session.get(InterfaceSettings, 1)
+        if settings is None:
+            settings = InterfaceSettings(id=1)
+            session.add(settings)
+            session.commit()
 
 
 def ensure_bug_table() -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -47,6 +47,8 @@ from .schemas import (
     BenefitUsageUpdate,
     BenefitWindowExclusionCreate,
     BenefitWindowExclusionRead,
+    InterfaceSettingsRead,
+    InterfaceSettingsUpdate,
     BackupConnectionTestRequest,
     BackupConnectionTestResult,
     BackupSettingsRead,
@@ -134,6 +136,18 @@ async def on_shutdown() -> None:
 @app.get("/api/health")
 def healthcheck() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@app.get("/api/interface/settings", response_model=InterfaceSettingsRead)
+def read_interface_settings(session: Session = Depends(get_session)) -> InterfaceSettingsRead:
+    return crud.get_interface_settings(session)
+
+
+@app.put("/api/interface/settings", response_model=InterfaceSettingsRead)
+def write_interface_settings(
+    payload: InterfaceSettingsUpdate, session: Session = Depends(get_session)
+) -> InterfaceSettingsRead:
+    return crud.update_interface_settings(session, payload)
 
 
 @app.get("/api/bugs", response_model=List[BugRead])

--- a/backend/app/migrations.py
+++ b/backend/app/migrations.py
@@ -76,7 +76,48 @@ def _add_notification_reason_and_preferences(connection: Connection) -> None:
         )
 
 
+def _ensure_interface_settings(connection: Connection) -> None:
+    """Create the interface settings table and default record if required."""
+
+    tables = {
+        row[0]
+        for row in connection.exec_driver_sql(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )
+    }
+    if "interfacesettings" not in tables:
+        logger.info("Creating interfacesettings table")
+        connection.exec_driver_sql(
+            """
+            CREATE TABLE interfacesettings (
+                id INTEGER PRIMARY KEY,
+                theme_mode VARCHAR NOT NULL DEFAULT 'light'
+            )
+            """
+        )
+    columns = {
+        row[1]
+        for row in connection.exec_driver_sql("PRAGMA table_info(interfacesettings)")
+    }
+    if "theme_mode" not in columns:
+        logger.info("Adding interfacesettings.theme_mode column")
+        connection.exec_driver_sql(
+            "ALTER TABLE interfacesettings ADD COLUMN theme_mode VARCHAR NOT NULL DEFAULT 'light'"
+        )
+        connection.exec_driver_sql(
+            "UPDATE interfacesettings SET theme_mode='light' WHERE theme_mode IS NULL"
+        )
+    rows = connection.exec_driver_sql("SELECT id FROM interfacesettings").fetchall()
+    existing_ids = {row[0] for row in rows}
+    if 1 not in existing_ids:
+        logger.info("Seeding default interface settings row")
+        connection.exec_driver_sql(
+            "INSERT INTO interfacesettings (id, theme_mode) VALUES (1, 'light')"
+        )
+
+
 MIGRATIONS: Sequence[tuple[str, MigrationFunc]] = (
+    ("2024101201_create_interface_settings", _ensure_interface_settings),
     ("2024100301_add_notification_reason_and_preferences", _add_notification_reason_and_preferences),
 )
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -32,6 +32,13 @@ class YearTrackingMode(str, Enum):
     anniversary = "anniversary"
 
 
+class ThemeMode(str, Enum):
+    """Supported interface theme variants."""
+
+    light = "light"
+    dark = "dark"
+
+
 class CreditCard(SQLModel, table=True):
     """Credit card stored in the system."""
 
@@ -201,5 +208,15 @@ class Bug(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     completed_at: Optional[datetime] = Field(
         default=None, description="When the bug was marked complete"
+    )
+
+
+class InterfaceSettings(SQLModel, table=True):
+    """Global interface preferences shared across the application."""
+
+    id: Optional[int] = Field(default=1, primary_key=True)
+    theme_mode: ThemeMode = Field(
+        default=ThemeMode.light,
+        description="Preferred UI theme for all users",
     )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Sequence
 from pydantic import ConfigDict, field_validator, model_validator
 from sqlmodel import Field, SQLModel
 
-from .models import BenefitFrequency, BenefitType, YearTrackingMode
+from .models import BenefitFrequency, BenefitType, ThemeMode, YearTrackingMode
 
 
 WINDOW_COUNT_BY_FREQUENCY: dict[BenefitFrequency, int] = {
@@ -118,6 +118,20 @@ class BugRead(BugBase):
     completed_at: Optional[datetime] = None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class InterfaceSettingsBase(SQLModel):
+    theme_mode: ThemeMode = Field(default=ThemeMode.light)
+
+
+class InterfaceSettingsRead(InterfaceSettingsBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class InterfaceSettingsUpdate(SQLModel):
+    theme_mode: ThemeMode
 
 
 class BenefitBase(SQLModel):

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -2,10 +2,132 @@
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color: #0f172a;
-  background-color: #f1f5f9;
+  color: var(--color-text-primary);
+  background-color: var(--color-surface-base);
+  color-scheme: light;
+
+  --color-text-primary: #0f172a;
+  --color-text-heading: #111827;
+  --color-text-secondary: #475569;
+  --color-text-tertiary: #64748b;
+  --color-text-muted: #94a3b8;
+  --color-text-inverse: #f8fafc;
+
+  --color-surface-base: #f1f5f9;
+  --color-body-gradient-start: #e0f2fe;
+  --color-body-gradient-end: #f8fafc;
+  --color-surface-overlay: rgba(255, 255, 255, 0.85);
+  --color-surface-overlay-strong: rgba(255, 255, 255, 0.95);
+  --color-surface-overlay-muted: rgba(255, 255, 255, 0.75);
+  --color-surface-overlay-faint: rgba(255, 255, 255, 0.6);
+
+  --color-border-subtle: rgba(148, 163, 184, 0.35);
+  --color-border-subtle-strong: rgba(148, 163, 184, 0.4);
+  --color-border-strong: rgba(226, 232, 240, 0.6);
+  --color-border-stronger: rgba(226, 232, 240, 0.8);
+  --color-border-strongest: rgba(226, 232, 240, 0.9);
+
+  --color-shadow-overlay: rgba(15, 23, 42, 0.18);
+  --color-shadow-strong: rgba(15, 23, 42, 0.35);
+
+  --color-app-header-bg: rgba(15, 23, 42, 0.72);
+  --color-app-header-border: rgba(255, 255, 255, 0.12);
+
+  --color-nav-toggle-border: rgba(148, 163, 184, 0.35);
+  --color-nav-toggle-background: rgba(15, 23, 42, 0.35);
+  --color-nav-backdrop: rgba(15, 23, 42, 0.5);
+  --color-nav-drawer-bg: rgba(15, 23, 42, 0.92);
+  --color-nav-drawer-shadow: rgba(15, 23, 42, 0.35);
+  --color-nav-button: #e2e8f0;
+  --color-nav-button-hover: rgba(148, 163, 184, 0.22);
+  --color-nav-button-active: rgba(255, 255, 255, 0.2);
+
+  --color-icon-button: #475569;
+  --color-icon-button-hover: rgba(148, 163, 184, 0.18);
+
+  --color-error-text: #b91c1c;
+  --color-error-border: rgba(248, 113, 113, 0.35);
+  --color-error-background: rgba(254, 242, 242, 0.65);
+
+  --color-empty-state-background: var(--color-surface-overlay-muted);
+  --color-empty-state-border: rgba(148, 163, 184, 0.35);
+
+  --color-admin-table-header-bg: rgba(248, 250, 252, 0.85);
+  --color-admin-table-bg: rgba(255, 255, 255, 0.95);
+
+  --color-table-border: rgba(226, 232, 240, 0.6);
+
+  --color-modal-backdrop: rgba(15, 23, 42, 0.5);
+
+  --color-theme-toggle-hover: rgba(148, 163, 184, 0.15);
+  --color-theme-toggle-track: rgba(148, 163, 184, 0.25);
+  --color-theme-toggle-track-active: rgba(59, 130, 246, 0.55);
+  --color-theme-toggle-thumb: #ffffff;
+  --color-value-bar-track: rgba(148, 163, 184, 0.25);
+  --color-card-border: rgba(148, 163, 184, 0.15);
+
   --benefit-card-min-height: 220px;
   --page-padding: clamp(1rem, 4vw, 3rem);
+}
+
+:root[data-theme='dark'],
+[data-theme='dark'] {
+  color-scheme: dark;
+  --color-text-primary: #e2e8f0;
+  --color-text-heading: #f8fafc;
+  --color-text-secondary: #cbd5f5;
+  --color-text-tertiary: #a5b4fc;
+  --color-text-muted: #94a3b8;
+
+  --color-surface-base: #0b1220;
+  --color-body-gradient-start: #0f172a;
+  --color-body-gradient-end: #1e293b;
+  --color-surface-overlay: rgba(15, 23, 42, 0.85);
+  --color-surface-overlay-strong: rgba(15, 23, 42, 0.92);
+  --color-surface-overlay-muted: rgba(15, 23, 42, 0.78);
+  --color-surface-overlay-faint: rgba(15, 23, 42, 0.6);
+
+  --color-border-subtle: rgba(71, 85, 105, 0.6);
+  --color-border-subtle-strong: rgba(71, 85, 105, 0.55);
+  --color-border-strong: rgba(71, 85, 105, 0.75);
+  --color-border-stronger: rgba(100, 116, 139, 0.7);
+  --color-border-strongest: rgba(148, 163, 184, 0.55);
+
+  --color-shadow-overlay: rgba(2, 6, 23, 0.65);
+  --color-shadow-strong: rgba(2, 6, 23, 0.65);
+
+  --color-app-header-bg: rgba(15, 23, 42, 0.9);
+  --color-app-header-border: rgba(148, 163, 184, 0.25);
+
+  --color-nav-toggle-border: rgba(71, 85, 105, 0.6);
+  --color-nav-toggle-background: rgba(30, 41, 59, 0.75);
+  --color-nav-backdrop: rgba(2, 6, 23, 0.65);
+  --color-nav-drawer-bg: rgba(15, 23, 42, 0.98);
+  --color-nav-drawer-shadow: rgba(2, 6, 23, 0.5);
+  --color-nav-button: #f1f5f9;
+  --color-nav-button-hover: rgba(148, 163, 184, 0.25);
+  --color-nav-button-active: rgba(59, 130, 246, 0.35);
+
+  --color-icon-button: #cbd5f5;
+  --color-icon-button-hover: rgba(148, 163, 184, 0.25);
+
+  --color-error-border: rgba(248, 113, 113, 0.45);
+  --color-error-background: rgba(127, 29, 29, 0.35);
+
+  --color-empty-state-background: rgba(15, 23, 42, 0.85);
+  --color-empty-state-border: rgba(71, 85, 105, 0.6);
+
+  --color-admin-table-header-bg: rgba(30, 41, 59, 0.9);
+  --color-admin-table-bg: rgba(15, 23, 42, 0.95);
+
+  --color-modal-backdrop: rgba(2, 6, 23, 0.7);
+
+  --color-theme-toggle-hover: rgba(148, 163, 184, 0.2);
+  --color-theme-toggle-track: rgba(71, 85, 105, 0.7);
+  --color-theme-toggle-track-active: rgba(96, 165, 250, 0.55);
+  --color-theme-toggle-thumb: #0f172a;
+  --color-value-bar-track: rgba(71, 85, 105, 0.65);
+  --color-card-border: rgba(71, 85, 105, 0.5);
 }
 
 * {
@@ -15,7 +137,11 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top left, #e0f2fe, #f8fafc 55%);
+  background: radial-gradient(
+    circle at top left,
+    var(--color-body-gradient-start),
+    var(--color-body-gradient-end) 55%
+  );
 }
 
 .app-shell {
@@ -25,10 +151,10 @@ body {
 }
 
 .app-header {
-  background: rgba(15, 23, 42, 0.72);
+  background: var(--color-app-header-bg);
   backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-  color: #f8fafc;
+  border-bottom: 1px solid var(--color-app-header-border);
+  color: var(--color-text-inverse);
   position: sticky;
   top: 0;
   z-index: 20;
@@ -61,14 +187,14 @@ body {
 }
 
 .nav-toggle {
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid var(--color-nav-toggle-border);
+  background: var(--color-nav-toggle-background);
 }
 
 .nav-button {
   background: transparent;
   border: none;
-  color: #e2e8f0;
+  color: var(--color-nav-button);
   padding: 0.6rem 0.9rem;
   border-radius: 8px;
   cursor: pointer;
@@ -80,12 +206,12 @@ body {
 }
 
 .nav-button:hover {
-  background-color: rgba(148, 163, 184, 0.22);
+  background-color: var(--color-nav-button-hover);
 }
 
 .nav-button.active {
-  background-color: rgba(255, 255, 255, 0.2);
-  color: #ffffff;
+  background-color: var(--color-nav-button-active);
+  color: var(--color-text-inverse);
 }
 
 .header-actions {
@@ -98,7 +224,7 @@ body {
 .nav-drawer-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.5);
+  background: var(--color-nav-backdrop);
   backdrop-filter: blur(2px);
   z-index: 25;
 }
@@ -110,9 +236,9 @@ body {
   height: 100vh;
   width: min(80vw, 280px);
   padding: 4.25rem 1.5rem 2rem;
-  background: rgba(15, 23, 42, 0.92);
-  color: #e2e8f0;
-  box-shadow: 8px 0 24px rgba(15, 23, 42, 0.35);
+  background: var(--color-nav-drawer-bg);
+  color: var(--color-nav-button);
+  box-shadow: 8px 0 24px var(--color-nav-drawer-shadow);
   transform: translateX(-100%);
   transition: transform 0.25s ease;
   z-index: 30;
@@ -142,6 +268,108 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.nav-drawer__footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid var(--color-border-subtle);
+  background: transparent;
+  padding: 0.7rem 0.9rem;
+  color: inherit;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.theme-toggle:hover:not(:disabled) {
+  background: var(--color-theme-toggle-hover);
+  border-color: var(--color-border-subtle-strong);
+}
+
+.theme-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.theme-toggle__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: var(--color-surface-overlay-faint);
+  color: inherit;
+}
+
+.theme-toggle__icon svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.theme-toggle__labels {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+  text-align: left;
+}
+
+.theme-toggle__status {
+  font-weight: 600;
+}
+
+.theme-toggle__hint {
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary);
+}
+
+.theme-toggle__switch {
+  position: relative;
+  width: 2.4rem;
+  height: 1.2rem;
+  border-radius: 999px;
+  background: var(--color-theme-toggle-track);
+  transition: background-color 0.2s ease;
+}
+
+.theme-toggle__switch--on {
+  background: var(--color-theme-toggle-track-active);
+}
+
+.theme-toggle__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 50%;
+  background: var(--color-theme-toggle-thumb);
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.theme-toggle__switch--on .theme-toggle__thumb {
+  transform: translateX(1.2rem);
+}
+
+.theme-toggle__error {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-error-text);
 }
 
 .app-main {
@@ -179,7 +407,7 @@ button {
   border-radius: 6px;
   border: none;
   background: transparent;
-  color: #475569;
+  color: var(--color-icon-button);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
@@ -190,7 +418,7 @@ button {
 }
 
 .icon-button:hover {
-  background-color: rgba(148, 163, 184, 0.18);
+  background-color: var(--color-icon-button-hover);
   transform: translateY(-1px);
 }
 
@@ -199,7 +427,7 @@ button {
 }
 
 .icon-button.ghost:hover {
-  background-color: rgba(148, 163, 184, 0.18);
+  background-color: var(--color-icon-button-hover);
 }
 
 .icon-button.accent {
@@ -249,15 +477,15 @@ textarea {
 
 .error-message {
   margin-top: 2rem;
-  color: #b91c1c;
-  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: var(--color-error-text);
+  border: 1px solid var(--color-error-border);
   padding: 1rem;
   border-radius: 16px;
-  background: rgba(254, 242, 242, 0.65);
+  background: var(--color-error-background);
 }
 
 .page-subtitle {
-  color: #475569;
+  color: var(--color-text-secondary);
   margin-bottom: 2rem;
 }
 
@@ -292,22 +520,22 @@ textarea {
   border-collapse: collapse;
   border-radius: 16px;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--color-surface-overlay-strong);
 }
 
 .admin-table th,
 .admin-table td {
   padding: 0.85rem 1rem;
   text-align: left;
-  border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+  border-bottom: 1px solid var(--color-border-strong);
 }
 
 .admin-table th {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #475569;
-  background: rgba(248, 250, 252, 0.85);
+  color: var(--color-text-secondary);
+  background: var(--color-admin-table-header-bg);
 }
 
 .admin-table tr:last-child td {
@@ -322,12 +550,12 @@ textarea {
 
 .admin-card-name {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-text-primary);
 }
 
 .admin-card-slug {
   font-size: 0.8rem;
-  color: #64748b;
+  color: var(--color-text-tertiary);
 }
 
 .admin-actions {
@@ -348,9 +576,9 @@ textarea {
 
 .admin-benefit-card {
   padding: 0.85rem;
-  border: 1px solid rgba(226, 232, 240, 0.8);
+  border: 1px solid var(--color-border-stronger);
   border-radius: 14px;
-  background: rgba(248, 250, 252, 0.75);
+  background: var(--color-surface-overlay-muted);
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
@@ -415,9 +643,9 @@ textarea {
 }
 
 .notification-test-card {
-  border: 1px solid rgba(226, 232, 240, 0.7);
+  border: 1px solid var(--color-border-stronger);
   border-radius: 16px;
-  background: rgba(248, 250, 252, 0.85);
+  background: var(--color-admin-table-header-bg);
   padding: 1.25rem;
   display: flex;
   flex-direction: column;
@@ -429,7 +657,7 @@ textarea {
   margin: 0;
   font-size: 1.05rem;
   font-weight: 600;
-  color: #111827;
+  color: var(--color-text-heading);
 }
 
 .notification-test-card .helper-text {
@@ -444,10 +672,10 @@ textarea {
 
 .notification-result {
   border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  border: 1px solid var(--color-border-subtle-strong);
   padding: 0.75rem;
-  background: rgba(241, 245, 249, 0.5);
-  color: #334155;
+  background: var(--color-surface-overlay-faint);
+  color: var(--color-text-primary);
   font-size: 0.85rem;
 }
 
@@ -496,9 +724,9 @@ textarea {
 }
 
 .backup-status-card {
-  border: 1px solid rgba(226, 232, 240, 0.7);
+  border: 1px solid var(--color-border-stronger);
   border-radius: 16px;
-  background: rgba(248, 250, 252, 0.85);
+  background: var(--color-admin-table-header-bg);
   padding: 1.25rem;
   display: flex;
   flex-direction: column;
@@ -543,13 +771,13 @@ textarea {
   font-size: 0.72rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #64748b;
+  color: var(--color-text-tertiary);
 }
 
 .backup-status-entry dd {
   margin: 0;
   font-size: 0.95rem;
-  color: #0f172a;
+  color: var(--color-text-primary);
   font-weight: 500;
 }
 
@@ -565,7 +793,7 @@ textarea {
   margin: 0;
   font-size: 1.05rem;
   font-weight: 600;
-  color: #111827;
+  color: var(--color-text-heading);
 }
 
 .backup-import-actions {
@@ -580,13 +808,13 @@ textarea {
 .notification-category h4 {
   margin: 0 0 0.25rem;
   font-size: 0.85rem;
-  color: #0f172a;
+  color: var(--color-text-primary);
 }
 
 .notification-category ul {
   margin: 0;
   padding-left: 1.2rem;
-  color: #475569;
+  color: var(--color-text-secondary);
   font-size: 0.85rem;
 }
 
@@ -611,7 +839,7 @@ textarea {
   align-items: center;
   gap: 0.4rem;
   font-size: 0.85rem;
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .checkbox-option input {
@@ -640,26 +868,26 @@ textarea {
   flex-direction: column;
   gap: 0.3rem;
   font-size: 0.8rem;
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .admin-window-values input {
   padding: 0.4rem 0.5rem;
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  border: 1px solid var(--color-border-subtle-strong);
   border-radius: 0.4rem;
   font-size: 0.9rem;
-  color: #0f172a;
+  color: var(--color-text-primary);
 }
 
 .card {
-  background: linear-gradient(145deg, #ffffff 40%, #f8fafc 100%);
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  background: var(--color-surface-overlay-strong);
+  box-shadow: 0 20px 45px var(--color-shadow-overlay);
   border-radius: 18px;
   padding: 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  border: 1px solid rgba(148, 163, 184, 0.15);
+  border: 1px solid var(--color-card-border);
   max-width: 760px;
   width: 100%;
   margin: 0 auto;
@@ -674,7 +902,7 @@ textarea {
 .card-title {
   font-size: 1.35rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--color-text-primary);
 }
 
 .card-meta {
@@ -689,7 +917,7 @@ textarea {
   position: relative;
   height: 12px;
   border-radius: 999px;
-  background: rgba(148, 163, 184, 0.25);
+  background: var(--color-value-bar-track);
   overflow: hidden;
 }
 
@@ -712,7 +940,7 @@ textarea {
 .summary-row {
   display: flex;
   justify-content: space-between;
-  color: #475569;
+  color: var(--color-text-secondary);
   font-size: 0.95rem;
   gap: 0.75rem;
   flex-wrap: wrap;
@@ -773,14 +1001,14 @@ textarea {
 }
 
 .benefit-card {
-  background: #ffffff;
+  background: var(--color-surface-overlay-strong);
   border-radius: 16px;
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  border: 1px solid rgba(226, 232, 240, 0.9);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  border: 1px solid var(--color-border-strongest);
+  box-shadow: 0 12px 24px var(--color-shadow-overlay);
   min-height: var(--benefit-card-min-height);
 }
 
@@ -793,14 +1021,14 @@ textarea {
 .benefit-card.window-deleted {
   border-color: rgba(148, 163, 184, 0.55);
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
-  background: #f8fafc;
+  background: var(--color-surface-overlay);
   opacity: 0.72;
 }
 
 .benefit-card.window-deleted .benefit-name,
 .benefit-card.window-deleted .benefit-amount,
 .benefit-card.window-deleted .benefit-used {
-  color: #64748b;
+  color: var(--color-text-tertiary);
 }
 
 .benefit-header {
@@ -815,7 +1043,7 @@ textarea {
 .benefit-name {
   font-size: 1.05rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-text-primary);
   overflow-wrap: anywhere;
 }
 
@@ -827,7 +1055,7 @@ textarea {
 }
 
 .benefit-body {
-  color: #475569;
+  color: var(--color-text-secondary);
   font-size: 0.9rem;
   flex-grow: 1;
 }
@@ -842,7 +1070,7 @@ textarea {
 .helper-text {
   margin: 0.5rem 0 1rem;
   font-size: 0.85rem;
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .helper-text.error-text {
@@ -858,7 +1086,7 @@ textarea {
 }
 
 .helper-text.subtle-text {
-  color: #64748b;
+  color: var(--color-text-tertiary);
 }
 
 .history-table {
@@ -871,7 +1099,7 @@ textarea {
 .history-table td {
   padding: 0.6rem;
   text-align: left;
-  border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+  border-bottom: 1px solid var(--color-border-stronger);
 }
 
 .history-table tbody tr:nth-child(even) {
@@ -880,11 +1108,11 @@ textarea {
 
 .history-loading {
   font-size: 0.9rem;
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .notification-history-table-wrapper {
-  border: 1px solid rgba(226, 232, 240, 0.8);
+  border: 1px solid var(--color-border-stronger);
   border-radius: 16px;
   overflow: hidden;
   max-height: 24rem;
@@ -917,7 +1145,7 @@ textarea {
   flex: 1 1 220px;
   min-width: 200px;
   padding: 0.55rem 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.6);
+  border: 1px solid var(--color-border-strong);
   border-radius: 999px;
   font-size: 0.9rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
@@ -930,7 +1158,7 @@ textarea {
 }
 
 .notification-history-search input[type='search']:disabled {
-  background: rgba(226, 232, 240, 0.4);
+  background: var(--color-surface-overlay-faint);
   cursor: not-allowed;
 }
 
@@ -941,24 +1169,24 @@ textarea {
 .notification-history-table {
   width: 100%;
   border-collapse: collapse;
-  background: #ffffff;
+  background: var(--color-surface-overlay-strong);
 }
 
 .notification-history-table th,
 .notification-history-table td {
   padding: 0.65rem 0.85rem;
   text-align: left;
-  border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+  border-bottom: 1px solid var(--color-border-stronger);
   font-size: 0.9rem;
-  color: #1e293b;
+  color: var(--color-text-primary);
 }
 
 .notification-history-table th {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #64748b;
-  background: rgba(248, 250, 252, 0.8);
+  color: var(--color-text-tertiary);
+  background: var(--color-surface-overlay-muted);
 }
 
 .notification-history-table td:nth-child(6),
@@ -998,7 +1226,7 @@ textarea {
 .notification-type-settings .field-label {
   font-size: 0.85rem;
   font-weight: 600;
-  color: #1e293b;
+  color: var(--color-text-primary);
   margin-bottom: 0.35rem;
 }
 
@@ -1025,7 +1253,7 @@ textarea {
 
 .notification-type-label {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-text-primary);
 }
 
 .primary-button {
@@ -1068,9 +1296,9 @@ input,
 select,
 textarea {
   border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  border: 1px solid var(--color-border-subtle-strong);
   padding: 0.6rem 0.75rem;
-  background: #f8fafc;
+  background: var(--color-surface-overlay-muted);
   transition: border 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -1083,19 +1311,19 @@ textarea:focus {
 }
 
 .section-card {
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--color-surface-overlay);
   backdrop-filter: blur(14px);
   border-radius: 20px;
   padding: 1.75rem;
   margin-bottom: 2rem;
-  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.18);
+  box-shadow: 0 25px 60px var(--color-shadow-overlay);
 }
 
 .section-title {
   font-size: 1.3rem;
   font-weight: 600;
   margin-bottom: 1rem;
-  color: #111827;
+  color: var(--color-text-heading);
 }
 
 .section-header {
@@ -1109,7 +1337,7 @@ textarea:focus {
 
 .section-description {
   margin: 0;
-  color: #475569;
+  color: var(--color-text-secondary);
   line-height: 1.6;
 }
 
@@ -1130,11 +1358,11 @@ textarea:focus {
 
 .empty-state {
   text-align: center;
-  color: #64748b;
+  color: var(--color-text-tertiary);
   padding: 3rem 1rem;
-  border: 2px dashed rgba(148, 163, 184, 0.35);
+  border: 2px dashed var(--color-empty-state-border);
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.75);
+  background: var(--color-empty-state-background);
 }
 
 .modal-actions {
@@ -1159,7 +1387,7 @@ textarea:focus {
   gap: 0.75rem;
   padding: 0.85rem 1rem;
   border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid var(--color-border-subtle);
   background: rgba(248, 250, 252, 0.9);
   box-shadow: 0 10px 20px rgba(15, 23, 42, 0.06);
   cursor: grab;
@@ -1200,13 +1428,13 @@ textarea:focus {
   min-width: 1.75rem;
   text-align: center;
   font-weight: 600;
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .card-sort-name {
   flex: 1;
   font-weight: 500;
-  color: #0f172a;
+  color: var(--color-text-primary);
   word-break: break-word;
 }
 
@@ -1261,7 +1489,7 @@ textarea:focus {
 
 .history-window-label {
   font-size: 0.9rem;
-  color: #475569;
+  color: var(--color-text-secondary);
   margin-bottom: 0.75rem;
 }
 
@@ -1271,7 +1499,7 @@ textarea:focus {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  color: #94a3b8;
+  color: var(--color-text-muted);
 }
 
 .card-history-grid {
@@ -1283,8 +1511,8 @@ textarea:focus {
 }
 
 .history-card {
-  background: linear-gradient(145deg, #ffffff, #f8fafc 85%);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: var(--color-surface-overlay-strong);
+  border: 1px solid var(--color-card-border);
   border-radius: 16px;
   padding: 1rem 1.25rem;
   display: flex;
@@ -1304,12 +1532,12 @@ textarea:focus {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-text-primary);
 }
 
 .history-card__subtitle {
   margin: 0.25rem 0 0;
-  color: #64748b;
+  color: var(--color-text-tertiary);
   font-size: 0.85rem;
 }
 
@@ -1317,7 +1545,7 @@ textarea:focus {
   display: flex;
   gap: 1rem;
   flex-wrap: wrap;
-  color: #475569;
+  color: var(--color-text-secondary);
   font-size: 0.9rem;
 }
 
@@ -1328,9 +1556,9 @@ textarea:focus {
 }
 
 .history-benefit-card {
-  background: #ffffff;
+  background: var(--color-surface-overlay-strong);
   border-radius: 12px;
-  border: 1px solid rgba(226, 232, 240, 0.8);
+  border: 1px solid var(--color-border-stronger);
   padding: 0.75rem;
   display: flex;
   flex-direction: column;
@@ -1348,7 +1576,7 @@ textarea:focus {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-text-primary);
 }
 
 .history-benefit-subtitle {
@@ -1361,14 +1589,14 @@ textarea:focus {
 
 .history-benefit-description {
   margin: 0;
-  color: #475569;
+  color: var(--color-text-secondary);
   font-size: 0.9rem;
 }
 
 .history-benefit-summary {
   margin: 0;
   font-size: 0.9rem;
-  color: #0f172a;
+  color: var(--color-text-primary);
 }
 
 .history-benefit-entries {
@@ -1379,19 +1607,19 @@ textarea:focus {
   flex-direction: column;
   gap: 0.35rem;
   font-size: 0.85rem;
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .history-benefit-entries span {
   margin-left: 0.35rem;
-  color: #0f172a;
+  color: var(--color-text-primary);
   font-weight: 600;
 }
 
 .history-benefit-empty {
   margin: 0;
   font-size: 0.85rem;
-  color: #94a3b8;
+  color: var(--color-text-muted);
 }
 
 .window-grid {
@@ -1401,9 +1629,9 @@ textarea:focus {
 }
 
 .window-card {
-  background: #ffffff;
+  background: var(--color-surface-overlay-strong);
   border-radius: 12px;
-  border: 1px solid rgba(226, 232, 240, 0.8);
+  border: 1px solid var(--color-border-stronger);
   padding: 0.85rem;
   display: flex;
   flex-direction: column;
@@ -1455,7 +1683,7 @@ textarea:focus {
 .window-deleted {
   margin-top: 1.5rem;
   padding-top: 1rem;
-  border-top: 1px solid rgba(226, 232, 240, 0.8);
+  border-top: 1px solid var(--color-border-stronger);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -1465,7 +1693,7 @@ textarea:focus {
   margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-text-primary);
 }
 
 .window-deleted__list {
@@ -1483,7 +1711,7 @@ textarea:focus {
   justify-content: space-between;
   gap: 0.5rem;
   font-size: 0.85rem;
-  color: #334155;
+  color: var(--color-text-primary);
 }
 
 .window-deleted__label {
@@ -1494,7 +1722,7 @@ textarea:focus {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-text-primary);
 }
 
 .window-range,
@@ -1502,7 +1730,7 @@ textarea:focus {
 .window-remaining {
   margin: 0;
   font-size: 0.85rem;
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .radio-group {
@@ -1517,7 +1745,7 @@ textarea:focus {
   align-items: center;
   gap: 0.4rem;
   font-size: 0.9rem;
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .radio-option input {


### PR DESCRIPTION
## Summary
- add InterfaceSettings model, schema, CRUD helpers, and API endpoints for managing the global theme preference stored in the database
- extend database initialization and migrations to create and seed the interface settings table
- load and persist the theme preference in the frontend, add a navigation-drawer toggle, and introduce light/dark CSS themes driven by shared variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd391fd020832e80eab7dc995861f9