### PR TITLE
Add benefits analysis dashboard with charts

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1761,3 +1761,319 @@ textarea:focus {
     padding: 1.25rem;
   }
 }
+
+.analysis-section {
+  padding-bottom: 2.5rem;
+}
+
+.analysis-status {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.analysis-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.75rem;
+}
+
+.analysis-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.analysis-card--wide {
+  grid-column: 1 / -1;
+}
+
+@media (min-width: 960px) {
+  .analysis-card--wide {
+    grid-column: span 2;
+  }
+}
+
+.analysis-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.analysis-card__title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--color-text-heading);
+}
+
+.analysis-card__subtitle {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.analysis-card__metrics {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.analysis-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.analysis-metric__label {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary);
+}
+
+.analysis-metric__value {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: var(--color-text-heading);
+}
+
+.analysis-card__charts {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.analysis-card__charts--split > * {
+  flex: 1;
+}
+
+@media (min-width: 960px) {
+  .analysis-card__charts--split {
+    flex-direction: row;
+    align-items: stretch;
+  }
+}
+
+.analysis-card__centered {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 220px;
+}
+
+.analysis-summary {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.analysis-summary li {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+.analysis-summary strong {
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--color-text-heading);
+}
+
+.analysis-positive {
+  color: #16a34a;
+}
+
+.analysis-negative {
+  color: #dc2626;
+}
+
+.analysis-empty {
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1px dashed var(--color-border-subtle);
+  color: var(--color-text-secondary);
+  background: var(--color-surface-overlay-faint);
+  text-align: center;
+}
+
+.simple-pie-chart {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.simple-pie-chart__figure {
+  border-radius: 50%;
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+}
+
+.simple-pie-chart__center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  text-align: center;
+}
+
+.analysis-pie-total-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-tertiary);
+}
+
+.analysis-pie-total-value {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--color-text-heading);
+}
+
+.simple-pie-chart__legend {
+  width: 100%;
+}
+
+.simple-pie-chart__legend ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.simple-pie-chart__legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.simple-pie-chart__legend-swatch {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 0.3rem;
+}
+
+.simple-pie-chart__legend-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.simple-pie-chart__legend-value {
+  font-size: 0.8rem;
+  color: var(--color-text-tertiary);
+}
+
+.simple-bar-chart {
+  width: 100%;
+}
+
+.simple-bar-chart__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
+  gap: 1rem;
+  align-items: end;
+  min-height: 220px;
+}
+
+.simple-bar-chart__column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.simple-bar-chart__bar {
+  width: 100%;
+  border-radius: 0.65rem 0.65rem 0 0;
+  background: rgba(99, 102, 241, 0.18);
+  transition: height 0.3s ease;
+}
+
+.simple-bar-chart__label {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  word-break: break-word;
+}
+
+.simple-bar-chart__value {
+  font-size: 0.8rem;
+  color: var(--color-text-tertiary);
+}
+
+.simple-bar-chart__empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+.simple-line-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.simple-line-chart__canvas {
+  width: 100%;
+  height: 240px;
+}
+
+.simple-line-chart__canvas svg {
+  width: 100%;
+  height: 100%;
+}
+
+.simple-line-chart__axis {
+  stroke: var(--color-border-subtle);
+  stroke-width: 1;
+}
+
+.simple-line-chart__point {
+  stroke: var(--color-surface-base);
+  stroke-width: 0.6;
+}
+
+.simple-line-chart__legend {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.simple-line-chart__swatch {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 999px;
+  margin-right: 0.4rem;
+}
+
+.simple-line-chart__legend-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.simple-line-chart__empty {
+  text-align: center;
+  color: var(--color-text-secondary);
+  padding: 1.5rem 0;
+}

--- a/frontend/src/components/charts/SimpleBarChart.vue
+++ b/frontend/src/components/charts/SimpleBarChart.vue
@@ -1,0 +1,81 @@
+<script setup>
+import { computed } from 'vue'
+
+const FALLBACK_COLORS = [
+  '#6366f1',
+  '#4f46e5',
+  '#22c55e',
+  '#0ea5e9',
+  '#f97316',
+  '#ec4899',
+  '#a855f7',
+  '#14b8a6'
+]
+
+const props = defineProps({
+  data: {
+    type: Array,
+    default: () => []
+  },
+  ariaLabel: {
+    type: String,
+    default: 'Bar chart'
+  },
+  maxValue: {
+    type: Number,
+    default: null
+  }
+})
+
+const normalizedData = computed(() =>
+  (props.data || []).map((item, index) => {
+    const rawValue = Number(item?.value ?? 0)
+    const value = Number.isFinite(rawValue) ? rawValue : 0
+    return {
+      label:
+        typeof item?.label === 'string' && item.label.trim()
+          ? item.label.trim()
+          : `Item ${index + 1}`,
+      value,
+      color: item?.color || FALLBACK_COLORS[index % FALLBACK_COLORS.length],
+      displayValue:
+        typeof item?.displayValue === 'string'
+          ? item.displayValue
+          : new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(value)
+    }
+  })
+)
+
+const computedMax = computed(() => {
+  if (typeof props.maxValue === 'number' && Number.isFinite(props.maxValue) && props.maxValue > 0) {
+    return props.maxValue
+  }
+  const max = normalizedData.value.reduce((acc, item) => Math.max(acc, item.value), 0)
+  return max > 0 ? max : 0
+})
+
+const bars = computed(() => {
+  const max = computedMax.value
+  return normalizedData.value.map((item) => ({
+    ...item,
+    percent: max > 0 ? (item.value / max) * 100 : 0
+  }))
+})
+
+const hasAnyValue = computed(() => bars.value.some((bar) => bar.value > 0))
+</script>
+
+<template>
+  <figure class="simple-bar-chart" role="img" :aria-label="ariaLabel">
+    <div class="simple-bar-chart__grid" :class="{ 'simple-bar-chart__grid--empty': !hasAnyValue }">
+      <div v-for="bar in bars" :key="bar.label" class="simple-bar-chart__column">
+        <div class="simple-bar-chart__bar" :style="{ height: `${Math.min(Math.max(bar.percent, 0), 100)}%`, backgroundColor: bar.color }">
+          <span class="sr-only">{{ bar.label }}: {{ bar.displayValue }}</span>
+        </div>
+        <span class="simple-bar-chart__label" :title="bar.label">{{ bar.label }}</span>
+        <span class="simple-bar-chart__value">{{ bar.displayValue }}</span>
+      </div>
+      <p v-if="!bars.length" class="simple-bar-chart__empty">No data available</p>
+    </div>
+  </figure>
+</template>

--- a/frontend/src/components/charts/SimpleLineChart.vue
+++ b/frontend/src/components/charts/SimpleLineChart.vue
@@ -1,0 +1,193 @@
+<script setup>
+import { computed } from 'vue'
+
+const FALLBACK_COLORS = [
+  '#22c55e',
+  '#6366f1',
+  '#0ea5e9',
+  '#f97316',
+  '#ec4899',
+  '#a855f7',
+  '#14b8a6',
+  '#4f46e5'
+]
+
+const CHART_HEIGHT = 100
+const TOP_PADDING = 8
+const BOTTOM_PADDING = 12
+
+const props = defineProps({
+  points: {
+    type: Array,
+    default: () => []
+  },
+  series: {
+    type: Array,
+    default: () => []
+  },
+  ariaLabel: {
+    type: String,
+    default: 'Line chart'
+  },
+  yMax: {
+    type: Number,
+    default: null
+  }
+})
+
+const normalizedSeries = computed(() =>
+  (props.series || []).map((entry, index) => ({
+    key: entry?.key || `series-${index + 1}`,
+    label:
+      typeof entry?.label === 'string' && entry.label.trim()
+        ? entry.label.trim()
+        : `Series ${index + 1}`,
+    color: entry?.color || FALLBACK_COLORS[index % FALLBACK_COLORS.length]
+  }))
+)
+
+const normalizedPoints = computed(() =>
+  (props.points || []).map((point, index) => ({
+    label:
+      typeof point?.label === 'string' && point.label.trim()
+        ? point.label.trim()
+        : `Point ${index + 1}`,
+    values: point?.values && typeof point.values === 'object' ? point.values : {}
+  }))
+)
+
+const computedMax = computed(() => {
+  if (typeof props.yMax === 'number' && Number.isFinite(props.yMax) && props.yMax > 0) {
+    return props.yMax
+  }
+  let max = 0
+  for (const point of normalizedPoints.value) {
+    for (const series of normalizedSeries.value) {
+      const raw = Number(point.values?.[series.key] ?? 0)
+      const value = Number.isFinite(raw) ? raw : 0
+      if (value > max) {
+        max = value
+      }
+    }
+  }
+  return max > 0 ? max : 0
+})
+
+const xPositions = computed(() => {
+  const count = normalizedPoints.value.length
+  if (count <= 1) {
+    return [0]
+  }
+  const step = 100 / (count - 1)
+  return normalizedPoints.value.map((_, index) => index * step)
+})
+
+function valueToY(value, max) {
+  if (!(max > 0)) {
+    return CHART_HEIGHT - BOTTOM_PADDING
+  }
+  const clamped = Math.min(Math.max(value, 0), max)
+  const drawableHeight = CHART_HEIGHT - TOP_PADDING - BOTTOM_PADDING
+  return TOP_PADDING + (1 - clamped / max) * drawableHeight
+}
+
+const chartSeries = computed(() => {
+  const max = computedMax.value
+  return normalizedSeries.value.map((series, seriesIndex) => {
+    const coords = normalizedPoints.value.map((point, pointIndex) => {
+      const raw = Number(point.values?.[series.key] ?? 0)
+      const value = Number.isFinite(raw) ? raw : 0
+      const x = xPositions.value[pointIndex] ?? 0
+      const y = valueToY(value, max)
+      return { x, y, value }
+    })
+    const path = coords
+      .map((coord, index) => `${index === 0 ? 'M' : 'L'} ${coord.x} ${coord.y}`)
+      .join(' ')
+    return {
+      ...series,
+      coords,
+      path,
+      index: seriesIndex
+    }
+  })
+})
+
+const hasTimeline = computed(
+  () => normalizedPoints.value.length > 0 && normalizedSeries.value.length > 0
+)
+
+const accessibleRows = computed(() =>
+  normalizedPoints.value.map((point) => ({
+    label: point.label,
+    values: normalizedSeries.value.map((series) => ({
+      label: series.label,
+      value: new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(
+        Number(point.values?.[series.key] ?? 0)
+      )
+    }))
+  }))
+)
+</script>
+
+<template>
+  <figure class="simple-line-chart" role="img" :aria-label="ariaLabel">
+    <div v-if="hasTimeline" class="simple-line-chart__canvas">
+      <svg viewBox="0 0 100 100" preserveAspectRatio="none">
+        <line
+          class="simple-line-chart__axis"
+          x1="0"
+          :y1="100 - BOTTOM_PADDING"
+          x2="100"
+          :y2="100 - BOTTOM_PADDING"
+        />
+        <template v-for="series in chartSeries" :key="series.key">
+          <path
+            class="simple-line-chart__path"
+            :d="series.path"
+            fill="none"
+            :stroke="series.color"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <g>
+            <circle
+              v-for="(coord, index) in series.coords"
+              :key="`${series.key}-${index}`"
+              class="simple-line-chart__point"
+              :cx="coord.x"
+              :cy="coord.y"
+              r="1.8"
+              :fill="series.color"
+            >
+              <title>{{ series.label }} – {{ normalizedPoints[index].label }}: {{ coord.value.toLocaleString(undefined, { maximumFractionDigits: 2 }) }}</title>
+            </circle>
+          </g>
+        </template>
+      </svg>
+    </div>
+    <p v-else class="simple-line-chart__empty">No timeline data available</p>
+    <ul class="simple-line-chart__legend" aria-hidden="true">
+      <li v-for="series in chartSeries" :key="series.key">
+        <span class="simple-line-chart__swatch" :style="{ backgroundColor: series.color }"></span>
+        <span class="simple-line-chart__legend-label">{{ series.label }}</span>
+      </li>
+    </ul>
+    <table class="sr-only">
+      <caption>{{ ariaLabel }}</caption>
+      <thead>
+        <tr>
+          <th scope="col">Period</th>
+          <th v-for="series in chartSeries" :key="series.key" scope="col">{{ series.label }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in accessibleRows" :key="row.label">
+          <th scope="row">{{ row.label }}</th>
+          <td v-for="entry in row.values" :key="entry.label">{{ entry.value }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </figure>
+</template>

--- a/frontend/src/components/charts/SimplePieChart.vue
+++ b/frontend/src/components/charts/SimplePieChart.vue
@@ -1,0 +1,136 @@
+<script setup>
+import { computed } from 'vue'
+
+const FALLBACK_COLORS = [
+  '#4f46e5',
+  '#6366f1',
+  '#22c55e',
+  '#0ea5e9',
+  '#f97316',
+  '#ec4899',
+  '#a855f7',
+  '#14b8a6'
+]
+
+const props = defineProps({
+  data: {
+    type: Array,
+    default: () => []
+  },
+  size: {
+    type: Number,
+    default: 160
+  },
+  total: {
+    type: Number,
+    default: null
+  },
+  ariaLabel: {
+    type: String,
+    default: 'Pie chart'
+  },
+  showLegend: {
+    type: Boolean,
+    default: true
+  }
+})
+
+const normalizedData = computed(() =>
+  (props.data || []).map((item, index) => {
+    const value = Number(item?.value ?? 0)
+    return {
+      label:
+        typeof item?.label === 'string' && item.label.trim()
+          ? item.label.trim()
+          : `Segment ${index + 1}`,
+      value: Number.isFinite(value) ? value : 0,
+      color: item?.color || FALLBACK_COLORS[index % FALLBACK_COLORS.length]
+    }
+  })
+)
+
+const totalValue = computed(() => {
+  if (typeof props.total === 'number' && Number.isFinite(props.total)) {
+    return props.total
+  }
+  return normalizedData.value.reduce((acc, item) => acc + item.value, 0)
+})
+
+const segments = computed(() => {
+  const total = totalValue.value
+  if (total <= 0) {
+    return []
+  }
+  let offset = 0
+  return normalizedData.value
+    .filter((item) => item.value > 0)
+    .map((item) => {
+      const percent = (item.value / total) * 100
+      const segment = {
+        ...item,
+        start: offset,
+        end: offset + percent,
+        percent
+      }
+      offset += percent
+      return segment
+    })
+})
+
+const figureStyle = computed(() => {
+  const base = {
+    width: `${props.size}px`,
+    height: `${props.size}px`
+  }
+  if (!segments.value.length) {
+    return {
+      ...base,
+      background: 'conic-gradient(var(--chart-empty-color, #e2e8f0) 0 100%)'
+    }
+  }
+  const stops = segments.value
+    .map((segment) => `${segment.color} ${segment.start}% ${segment.end}%`)
+    .join(', ')
+  return {
+    ...base,
+    background: `conic-gradient(${stops})`
+  }
+})
+
+const formattedSegments = computed(() => {
+  const total = totalValue.value
+  return normalizedData.value.map((item) => {
+    const percent = total > 0 ? (item.value / total) * 100 : 0
+    return {
+      ...item,
+      percent
+    }
+  })
+})
+</script>
+
+<template>
+  <figure class="simple-pie-chart" role="img" :aria-label="ariaLabel">
+    <div class="simple-pie-chart__figure" :style="figureStyle">
+      <div class="simple-pie-chart__center">
+        <slot name="center">
+          <span class="simple-pie-chart__value">${{ totalValue.toFixed(2) }}</span>
+        </slot>
+      </div>
+    </div>
+    <figcaption v-if="showLegend" class="simple-pie-chart__legend" aria-hidden="true">
+      <ul>
+        <li v-for="segment in formattedSegments" :key="segment.label">
+          <span class="simple-pie-chart__legend-swatch" :style="{ backgroundColor: segment.color }"></span>
+          <span class="simple-pie-chart__legend-label">
+            {{ segment.label }}
+            <span class="simple-pie-chart__legend-value">
+              – ${{ segment.value.toFixed(2) }}
+              <span v-if="segment.percent > 0">({{ segment.percent.toFixed(1) }}%)</span>
+            </span>
+          </span>
+        </li>
+      </ul>
+    </figcaption>
+  </figure>
+</template>


### PR DESCRIPTION
## Summary
- add a benefits analysis view with annual fee insights, benefit trend charts, and portfolio summaries
- build lightweight pie, bar, and line chart components used across the new dashboard
- extend global styling to support the new analytics layout and chart visuals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6582f548832eb550fcf17700acb7