### PR TITLE
Revamp benefits analysis visuals

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1774,7 +1774,7 @@ textarea:focus {
 
 .analysis-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 1.5rem;
   margin-top: 1.75rem;
 }
@@ -1783,6 +1783,7 @@ textarea:focus {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  height: 100%;
 }
 
 .analysis-card--wide {
@@ -1793,6 +1794,18 @@ textarea:focus {
   .analysis-card--wide {
     grid-column: span 2;
   }
+}
+
+.analysis-card--visual {
+  align-items: stretch;
+}
+
+.analysis-card__visual {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.75rem 0;
 }
 
 .analysis-card__header {
@@ -1814,53 +1827,14 @@ textarea:focus {
   font-size: 0.95rem;
 }
 
-.analysis-card__metrics {
-  display: flex;
-  gap: 1.5rem;
-  flex-wrap: wrap;
-}
-
-.analysis-metric {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.analysis-metric__label {
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  font-size: 0.75rem;
-  color: var(--color-text-tertiary);
-}
-
-.analysis-metric__value {
-  font-size: 1.8rem;
+.analysis-highlight {
+  font-size: clamp(1.8rem, 2vw + 1.2rem, 2.6rem);
   font-weight: 600;
   color: var(--color-text-heading);
-}
-
-.analysis-card__charts {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.analysis-card__charts--split > * {
-  flex: 1;
-}
-
-@media (min-width: 960px) {
-  .analysis-card__charts--split {
-    flex-direction: row;
-    align-items: stretch;
-  }
-}
-
-.analysis-card__centered {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 220px;
+  background: var(--color-surface-overlay-faint);
+  padding: 1.25rem;
+  border-radius: 1rem;
+  text-align: center;
 }
 
 .analysis-summary {
@@ -1904,78 +1878,72 @@ textarea:focus {
 
 .simple-pie-chart {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
+  justify-content: center;
+  width: 100%;
 }
 
 .simple-pie-chart__figure {
-  border-radius: 50%;
-  position: relative;
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+  width: min(320px, 100%);
+  height: auto;
 }
 
-.simple-pie-chart__center {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.35rem;
-  text-align: center;
+.analysis-utilization-table-wrapper {
+  overflow-x: auto;
 }
 
-.analysis-pie-total-label {
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--color-text-tertiary);
+.analysis-utilization-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
 }
 
-.analysis-pie-total-value {
-  font-size: 1.15rem;
+.analysis-utilization-table th {
+  text-align: left;
+  font-weight: 600;
+  padding: 0.35rem 0.5rem 0.35rem 0;
+  min-width: 180px;
+}
+
+.analysis-utilization-table td {
+  padding: 0.35rem 0.5rem;
+  vertical-align: middle;
+}
+
+.analysis-utilization-card-name {
+  display: block;
   font-weight: 600;
   color: var(--color-text-heading);
 }
 
-.simple-pie-chart__legend {
-  width: 100%;
+.analysis-utilization-subtext {
+  display: block;
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
 }
 
-.simple-pie-chart__legend ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  color: var(--color-text-secondary);
-  font-size: 0.9rem;
+.analysis-utilization-bar {
+  position: relative;
+  height: 0.75rem;
+  background: var(--color-surface-overlay-faint);
+  border-radius: 999px;
+  overflow: hidden;
 }
 
-.simple-pie-chart__legend li {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
+.analysis-utilization-bar__fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  background: linear-gradient(90deg, #6366f1, #8b5cf6);
+  border-radius: inherit;
+  transition: width 0.3s ease;
 }
 
-.simple-pie-chart__legend-swatch {
-  width: 0.85rem;
-  height: 0.85rem;
-  border-radius: 0.3rem;
-}
-
-.simple-pie-chart__legend-label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-}
-
-.simple-pie-chart__legend-value {
-  font-size: 0.8rem;
-  color: var(--color-text-tertiary);
+.analysis-utilization-rate {
+  font-weight: 600;
+  color: var(--color-text-heading);
+  white-space: nowrap;
 }
 
 .simple-bar-chart {

--- a/frontend/src/components/charts/SimplePieChart.vue
+++ b/frontend/src/components/charts/SimplePieChart.vue
@@ -12,6 +12,12 @@ const FALLBACK_COLORS = [
   '#14b8a6'
 ]
 
+const VIEWBOX_SIZE = 240
+const CENTER = VIEWBOX_SIZE / 2
+const RADIUS = CENTER - 28
+const LABEL_RADIUS = RADIUS + 18
+const VALUE_RADIUS = RADIUS * 0.6
+
 const props = defineProps({
   data: {
     type: Array,
@@ -19,19 +25,11 @@ const props = defineProps({
   },
   size: {
     type: Number,
-    default: 160
-  },
-  total: {
-    type: Number,
-    default: null
+    default: 240
   },
   ariaLabel: {
     type: String,
     default: 'Pie chart'
-  },
-  showLegend: {
-    type: Boolean,
-    default: true
   }
 })
 
@@ -49,88 +47,138 @@ const normalizedData = computed(() =>
   })
 )
 
-const totalValue = computed(() => {
-  if (typeof props.total === 'number' && Number.isFinite(props.total)) {
-    return props.total
+const totalValue = computed(() =>
+  normalizedData.value.reduce((acc, item) => acc + item.value, 0)
+)
+
+const hasData = computed(() => totalValue.value > 0)
+
+function polarToCartesian(angle, radius) {
+  const radians = (angle * Math.PI) / 180
+  return {
+    x: CENTER + radius * Math.cos(radians),
+    y: CENTER + radius * Math.sin(radians)
   }
-  return normalizedData.value.reduce((acc, item) => acc + item.value, 0)
-})
+}
+
+function getAnchor(x) {
+  if (Math.abs(x - CENTER) < 4) {
+    return 'middle'
+  }
+  return x > CENTER ? 'start' : 'end'
+}
 
 const segments = computed(() => {
-  const total = totalValue.value
-  if (total <= 0) {
+  if (!hasData.value) {
     return []
   }
-  let offset = 0
+  let angleCursor = -90
   return normalizedData.value
     .filter((item) => item.value > 0)
     .map((item) => {
-      const percent = (item.value / total) * 100
-      const segment = {
+      const sweep = (item.value / totalValue.value) * 360
+      const startAngle = angleCursor
+      const endAngle = startAngle + sweep
+      const largeArc = sweep > 180 ? 1 : 0
+      const start = polarToCartesian(startAngle, RADIUS)
+      const end = polarToCartesian(endAngle, RADIUS)
+      const midAngle = startAngle + sweep / 2
+      const labelPoint = polarToCartesian(midAngle, LABEL_RADIUS)
+      const valuePoint = polarToCartesian(midAngle, VALUE_RADIUS)
+      angleCursor = endAngle
+      return {
         ...item,
-        start: offset,
-        end: offset + percent,
-        percent
+        path: `M ${CENTER} ${CENTER} L ${start.x} ${start.y} A ${RADIUS} ${RADIUS} 0 ${largeArc} 1 ${end.x} ${end.y} Z`,
+        labelPoint,
+        valuePoint,
+        labelAnchor: getAnchor(labelPoint.x),
+        valueAnchor: getAnchor(valuePoint.x)
       }
-      offset += percent
-      return segment
     })
 })
 
-const figureStyle = computed(() => {
-  const base = {
-    width: `${props.size}px`,
-    height: `${props.size}px`
-  }
-  if (!segments.value.length) {
-    return {
-      ...base,
-      background: 'conic-gradient(var(--chart-empty-color, #e2e8f0) 0 100%)'
-    }
-  }
-  const stops = segments.value
-    .map((segment) => `${segment.color} ${segment.start}% ${segment.end}%`)
-    .join(', ')
-  return {
-    ...base,
-    background: `conic-gradient(${stops})`
-  }
-})
-
-const formattedSegments = computed(() => {
-  const total = totalValue.value
-  return normalizedData.value.map((item) => {
-    const percent = total > 0 ? (item.value / total) * 100 : 0
-    return {
-      ...item,
-      percent
-    }
-  })
-})
+const formattedSegments = computed(() =>
+  segments.value.map((segment) => ({
+    ...segment,
+    displayValue: `$${segment.value.toFixed(2)}`
+  }))
+)
 </script>
 
 <template>
   <figure class="simple-pie-chart" role="img" :aria-label="ariaLabel">
-    <div class="simple-pie-chart__figure" :style="figureStyle">
-      <div class="simple-pie-chart__center">
-        <slot name="center">
-          <span class="simple-pie-chart__value">${{ totalValue.toFixed(2) }}</span>
-        </slot>
-      </div>
-    </div>
-    <figcaption v-if="showLegend" class="simple-pie-chart__legend" aria-hidden="true">
-      <ul>
-        <li v-for="segment in formattedSegments" :key="segment.label">
-          <span class="simple-pie-chart__legend-swatch" :style="{ backgroundColor: segment.color }"></span>
-          <span class="simple-pie-chart__legend-label">
+    <svg
+      class="simple-pie-chart__figure"
+      :width="size"
+      :height="size"
+      :viewBox="`0 0 ${VIEWBOX_SIZE} ${VIEWBOX_SIZE}`"
+    >
+      <g v-if="formattedSegments.length">
+        <path
+          v-for="segment in formattedSegments"
+          :key="segment.label"
+          :d="segment.path"
+          :fill="segment.color"
+        />
+        <g v-for="segment in formattedSegments" :key="`${segment.label}-labels`">
+          <text
+            class="simple-pie-chart__value"
+            :x="segment.valuePoint.x"
+            :y="segment.valuePoint.y"
+            :text-anchor="segment.valueAnchor"
+          >
+            {{ segment.displayValue }}
+          </text>
+          <text
+            class="simple-pie-chart__label"
+            :x="segment.labelPoint.x"
+            :y="segment.labelPoint.y"
+            :text-anchor="segment.labelAnchor"
+          >
             {{ segment.label }}
-            <span class="simple-pie-chart__legend-value">
-              – ${{ segment.value.toFixed(2) }}
-              <span v-if="segment.percent > 0">({{ segment.percent.toFixed(1) }}%)</span>
-            </span>
-          </span>
-        </li>
-      </ul>
-    </figcaption>
+          </text>
+        </g>
+      </g>
+      <g v-else>
+        <circle :cx="CENTER" :cy="CENTER" :r="RADIUS" class="simple-pie-chart__empty" />
+        <text class="simple-pie-chart__empty-text" :x="CENTER" :y="CENTER">No data</text>
+      </g>
+    </svg>
   </figure>
 </template>
+
+<style scoped>
+.simple-pie-chart {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.simple-pie-chart__figure {
+  max-width: 100%;
+}
+
+.simple-pie-chart__value {
+  font-size: 12px;
+  font-weight: 600;
+  fill: var(--color-text-heading, #0f172a);
+}
+
+.simple-pie-chart__label {
+  font-size: 10px;
+  fill: var(--color-text-tertiary, #64748b);
+}
+
+.simple-pie-chart__empty {
+  fill: none;
+  stroke: var(--color-border-subtle, #e2e8f0);
+  stroke-width: 12;
+}
+
+.simple-pie-chart__empty-text {
+  font-size: 12px;
+  fill: var(--color-text-tertiary, #94a3b8);
+  text-anchor: middle;
+  dominant-baseline: middle;
+}
+</style>

--- a/frontend/src/components/charts/TimelineBarChart.vue
+++ b/frontend/src/components/charts/TimelineBarChart.vue
@@ -1,0 +1,235 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  data: {
+    type: Array,
+    default: () => []
+  },
+  ariaLabel: {
+    type: String,
+    default: 'Timeline bar chart'
+  },
+  maxValue: {
+    type: Number,
+    default: null
+  }
+})
+
+const VIEWBOX_WIDTH = 640
+const VIEWBOX_HEIGHT = 320
+const PADDING = { top: 20, right: 32, bottom: 48, left: 72 }
+
+const normalizedData = computed(() =>
+  (props.data || []).map((item, index) => {
+    const rawValue = Number(item?.value ?? 0)
+    const value = Number.isFinite(rawValue) && rawValue > 0 ? rawValue : 0
+    return {
+      label:
+        typeof item?.label === 'string' && item.label.trim()
+          ? item.label.trim()
+          : `Item ${index + 1}`,
+      fullLabel:
+        typeof item?.fullLabel === 'string' && item.fullLabel.trim()
+          ? item.fullLabel.trim()
+          : undefined,
+      value,
+      color: item?.color || '#6366f1',
+      displayValue:
+        typeof item?.displayValue === 'string'
+          ? item.displayValue
+          : new Intl.NumberFormat(undefined, {
+              style: 'currency',
+              currency: 'USD',
+              minimumFractionDigits: 0
+            }).format(value)
+    }
+  })
+)
+
+const computedMax = computed(() => {
+  if (typeof props.maxValue === 'number' && Number.isFinite(props.maxValue) && props.maxValue > 0) {
+    return props.maxValue
+  }
+  const max = normalizedData.value.reduce((acc, item) => Math.max(acc, item.value), 0)
+  return max > 0 ? max : 0
+})
+
+const innerWidth = VIEWBOX_WIDTH - PADDING.left - PADDING.right
+const innerHeight = VIEWBOX_HEIGHT - PADDING.top - PADDING.bottom
+
+const bars = computed(() => {
+  const data = normalizedData.value
+  if (!data.length || computedMax.value <= 0) {
+    return []
+  }
+  const band = innerWidth / data.length
+  const barWidth = Math.max(Math.min(band * 0.6, 48), 24)
+  return data.map((item, index) => {
+    const height = (item.value / computedMax.value) * innerHeight
+    const x = PADDING.left + index * band + (band - barWidth) / 2
+    const y = PADDING.top + (innerHeight - height)
+    const labelX = PADDING.left + index * band + band / 2
+    return {
+      ...item,
+      x,
+      y,
+      height,
+      width: barWidth,
+      labelX
+    }
+  })
+})
+
+const yTicks = computed(() => {
+  const max = computedMax.value
+  if (max <= 0) {
+    return []
+  }
+  const steps = 4
+  const increment = max / steps
+  return Array.from({ length: steps + 1 }, (_, index) => {
+    const value = increment * index
+    const y = PADDING.top + (innerHeight - (value / max) * innerHeight)
+    return {
+      value,
+      y,
+      label: new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value)
+    }
+  })
+})
+
+const hasData = computed(() => bars.value.length > 0)
+</script>
+
+<template>
+  <figure class="timeline-bar-chart" role="img" :aria-label="ariaLabel">
+    <svg
+      class="timeline-bar-chart__figure"
+      :viewBox="`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      <g v-if="hasData">
+        <line
+          class="timeline-bar-chart__axis"
+          :x1="PADDING.left"
+          :y1="PADDING.top + innerHeight"
+          :x2="PADDING.left + innerWidth"
+          :y2="PADDING.top + innerHeight"
+        />
+        <g class="timeline-bar-chart__grid">
+          <g v-for="tick in yTicks" :key="tick.value">
+            <line
+              :x1="PADDING.left"
+              :y1="tick.y"
+              :x2="PADDING.left + innerWidth"
+              :y2="tick.y"
+            />
+            <text
+              class="timeline-bar-chart__tick-label"
+              :x="PADDING.left - 12"
+              :y="tick.y + 4"
+              text-anchor="end"
+            >
+              {{ tick.label }}
+            </text>
+          </g>
+        </g>
+        <g>
+          <g v-for="bar in bars" :key="bar.label">
+            <rect
+              class="timeline-bar-chart__bar"
+              :x="bar.x"
+              :y="bar.y"
+              :width="bar.width"
+              :height="bar.height"
+              :fill="bar.color"
+              rx="6"
+            />
+            <text
+              v-if="bar.value > 0"
+              class="timeline-bar-chart__value"
+              :x="bar.x + bar.width / 2"
+              :y="bar.y - 8"
+              text-anchor="middle"
+            >
+              {{ bar.displayValue }}
+            </text>
+            <text
+              class="timeline-bar-chart__label"
+              :x="bar.labelX"
+              :y="PADDING.top + innerHeight + 24"
+              text-anchor="middle"
+            >
+              {{ bar.label }}
+            </text>
+            <text
+              v-if="bar.fullLabel"
+              class="timeline-bar-chart__sublabel"
+              :x="bar.labelX"
+              :y="PADDING.top + innerHeight + 40"
+              text-anchor="middle"
+            >
+              {{ bar.fullLabel }}
+            </text>
+          </g>
+        </g>
+      </g>
+      <g v-else>
+        <text class="timeline-bar-chart__empty" x="50%" y="55%" text-anchor="middle">No data available</text>
+      </g>
+    </svg>
+  </figure>
+</template>
+
+<style scoped>
+.timeline-bar-chart {
+  width: 100%;
+}
+
+.timeline-bar-chart__figure {
+  width: 100%;
+  height: auto;
+}
+
+.timeline-bar-chart__axis {
+  stroke: var(--color-border, rgba(148, 163, 184, 0.5));
+  stroke-width: 2;
+}
+
+.timeline-bar-chart__grid line {
+  stroke: rgba(148, 163, 184, 0.2);
+  stroke-width: 1;
+}
+
+.timeline-bar-chart__tick-label {
+  font-size: 12px;
+  fill: var(--color-text-tertiary, #64748b);
+}
+
+.timeline-bar-chart__bar {
+  transition: height 0.3s ease;
+}
+
+.timeline-bar-chart__value {
+  font-size: 12px;
+  font-weight: 600;
+  fill: var(--color-text-heading, #0f172a);
+}
+
+.timeline-bar-chart__label {
+  font-size: 12px;
+  font-weight: 600;
+  fill: var(--color-text-secondary, #475569);
+}
+
+.timeline-bar-chart__sublabel {
+  font-size: 10px;
+  fill: var(--color-text-tertiary, #94a3b8);
+}
+
+.timeline-bar-chart__empty {
+  font-size: 14px;
+  fill: var(--color-text-tertiary, #94a3b8);
+}
+</style>


### PR DESCRIPTION
## Summary
- reorganize the benefits analysis page into standalone cards with refreshed layouts
- replace the pie chart implementation with labeled slices and add a new annual fee timeline bar chart
- update styling so analysis content scales inside cards, including a horizontal utilization table

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd73eebfa0832ea10e5dcafa68f866