### PR TITLE
Add Highcharts drilldown pie chart and refresh utilization display

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.7.7",
+        "highcharts": "^12.4.0",
+        "highcharts-vue": "^2.0.1",
         "vue": "^3.4.21"
       },
       "devDependencies": {
@@ -1207,6 +1209,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highcharts": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-12.4.0.tgz",
+      "integrity": "sha512-o6UxxfChSUrvrZUbWrAuqL1HO/+exhAUPcZY6nnqLsadZQlnP16d082sg7DnXKZCk1gtfkyfkp6g3qkIZ9miZg==",
+      "license": "https://www.highcharts.com/license"
+    },
+    "node_modules/highcharts-vue": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/highcharts-vue/-/highcharts-vue-2.0.1.tgz",
+      "integrity": "sha512-7yVaKvsWlx7OgmKFXE2D99fi/0tr2A85H4KUz3jL7CRQhAwvEvXgtDIyTBGLHJsOC5L9VlppAI7k6KfIi0j0hg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "peerDependencies": {
+        "highcharts": ">=5.0.0",
+        "vue": ">=3.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "highcharts": "^12.4.0",
+    "highcharts-vue": "^2.0.1",
     "vue": "^3.4.21"
   },
   "devDependencies": {

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1910,33 +1910,33 @@ textarea:focus {
   vertical-align: middle;
 }
 
+.analysis-utilization-table td:nth-child(2) {
+  width: 100%;
+}
+
 .analysis-utilization-card-name {
   display: block;
   font-weight: 600;
   color: var(--color-text-heading);
 }
 
-.analysis-utilization-subtext {
-  display: block;
-  font-size: 0.85rem;
-  margin-top: 0.15rem;
+.analysis-utilization-progress {
+  width: 100%;
+  display: flex;
+  align-items: center;
 }
 
-.analysis-utilization-bar {
-  position: relative;
-  height: 0.75rem;
-  background: var(--color-surface-overlay-faint);
+.analysis-utilization-progress__track {
+  width: 100%;
+  height: 0.55rem;
   border-radius: 999px;
+  background: var(--color-value-bar-track);
   overflow: hidden;
 }
 
-.analysis-utilization-bar__fill {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  background: linear-gradient(90deg, #6366f1, #8b5cf6);
-  border-radius: inherit;
+.analysis-utilization-progress__fill {
+  height: 100%;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
   transition: width 0.3s ease;
 }
 

--- a/frontend/src/components/charts/DrilldownPieChart.vue
+++ b/frontend/src/components/charts/DrilldownPieChart.vue
@@ -1,0 +1,141 @@
+<script setup>
+import { computed } from 'vue'
+import Highcharts from 'highcharts'
+import drilldownModule from 'highcharts/modules/drilldown'
+import { Chart } from 'highcharts-vue'
+
+if (!Highcharts.__creditwatchDrilldownInitialized) {
+  drilldownModule(Highcharts)
+  Highcharts.__creditwatchDrilldownInitialized = true
+}
+
+const props = defineProps({
+  series: {
+    type: Array,
+    default: () => []
+  },
+  drilldownSeries: {
+    type: Array,
+    default: () => []
+  },
+  ariaLabel: {
+    type: String,
+    default: 'Pie chart with drilldown'
+  }
+})
+
+const formatter = new Intl.NumberFormat(undefined, {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+})
+
+const chartOptions = computed(() => {
+  const primarySeries = (props.series || []).map((point) => ({
+    name: point.name ?? point.label,
+    y: Number(point.y ?? point.value ?? 0),
+    color: point.color,
+    drilldown: point.drilldown,
+    displayValue: point.displayValue || formatter.format(Number(point.y ?? point.value ?? 0))
+  }))
+
+  const drilldownSeries = (props.drilldownSeries || []).map((series) => ({
+    ...series,
+    data: (series.data || []).map((entry) => ({
+      name: entry.name ?? entry.label,
+      y: Number(entry.y ?? entry.value ?? 0),
+      displayValue: entry.displayValue || formatter.format(Number(entry.y ?? entry.value ?? 0))
+    }))
+  }))
+
+  return {
+    chart: {
+      type: 'pie',
+      backgroundColor: 'transparent'
+    },
+    title: { text: undefined },
+    subtitle: { text: undefined },
+    accessibility: {
+      announceNewData: {
+        enabled: true
+      }
+    },
+    legend: {
+      enabled: false
+    },
+    credits: {
+      enabled: false
+    },
+    tooltip: {
+      useHTML: true,
+      formatter() {
+        const point = this.point || {}
+        const label = point.name || point.category
+        const value = point.displayValue || formatter.format(Number(point.y || 0))
+        return `<strong>${label}</strong><br/><span>${value}</span>`
+      }
+    },
+    plotOptions: {
+      series: {
+        borderWidth: 0,
+        dataLabels: {
+          enabled: true,
+          formatter() {
+            const point = this.point || {}
+            const label = point.name || point.category
+            const value = point.displayValue || formatter.format(Number(point.y || 0))
+            return `<span style="font-weight:600;">${label}</span><br/><span style="color:var(--color-text-tertiary,#64748b);">${value}</span>`
+          },
+          style: {
+            textOutline: 'none',
+            fontSize: '11px'
+          }
+        }
+      }
+    },
+    series: [
+      {
+        name: 'Annual fees',
+        colorByPoint: true,
+        data: primarySeries
+      }
+    ],
+    drilldown: {
+      activeAxisLabelStyle: {
+        color: 'var(--color-text-heading, #0f172a)'
+      },
+      activeDataLabelStyle: {
+        color: 'var(--color-text-heading, #0f172a)'
+      },
+      series: drilldownSeries.map((series) => ({
+        type: 'column',
+        ...series,
+        data: series.data.map((entry) => ({
+          name: entry.name,
+          y: entry.y,
+          displayValue: entry.displayValue
+        }))
+      }))
+    }
+  }
+})
+</script>
+
+<template>
+  <div class="drilldown-pie-chart" role="img" :aria-label="ariaLabel">
+    <Chart :options="chartOptions" :highcharts="Highcharts" class="drilldown-pie-chart__chart" />
+  </div>
+</template>
+
+<style scoped>
+.drilldown-pie-chart {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.drilldown-pie-chart__chart {
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary
- integrate a Highcharts-based drilldown pie chart for the annual fees section on the benefits analysis page
- restyle the utilization rate table with progress bars while keeping rows sorted by highest utilization
- add Highcharts dependencies and supporting component for the new visualization

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddb0591c14832e9fe1bd42c16da7d5