### PR TITLE
Revamp benefits analysis charts and layout

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1808,29 +1808,6 @@ const benefitsAnalysisBenefitsByType = computed(() => {
   }))
 })
 
-const benefitsAnalysisBenefitsByFrequency = computed(() => {
-  const counts = new Map()
-  for (const { benefit } of benefitsAnalysisBenefitEntries.value) {
-    const frequency = typeof benefit?.frequency === 'string' && benefit.frequency.trim()
-      ? benefit.frequency.trim()
-      : 'unspecified'
-    counts.set(frequency, (counts.get(frequency) ?? 0) + 1)
-  }
-  const sorted = Array.from(counts.entries()).sort((a, b) => b[1] - a[1])
-  return sorted.map(([frequency, count], index) => {
-    const label =
-      frequency === 'unspecified'
-        ? 'Unspecified'
-        : frequency.charAt(0).toUpperCase() + frequency.slice(1)
-    return {
-      label,
-      value: count,
-      color: getAnalysisColor(index),
-      displayValue: count.toLocaleString()
-    }
-  })
-})
-
 const benefitsAnalysisMissedValue = computed(() =>
   benefitsAnalysisBenefitEntries.value.reduce(
     (acc, { benefit }) => acc + Number(benefit?.missed_window_value ?? 0),
@@ -1845,6 +1822,17 @@ const benefitsAnalysisHasCards = computed(
 const benefitsAnalysisHasBenefits = computed(
   () => benefitsAnalysisBenefitEntries.value.length > 0
 )
+
+function analysisCardUnits(minUnits, maxUnits) {
+  const safeMin = Number.isFinite(Number(minUnits)) ? Number(minUnits) : 1
+  const safeMax = Number.isFinite(Number(maxUnits)) ? Number(maxUnits) : safeMin
+  const clampedMin = Math.max(1, Math.min(safeMin, 6))
+  const clampedMax = Math.max(clampedMin, Math.min(safeMax, 6))
+  return {
+    '--analysis-card-min-units': clampedMin,
+    '--analysis-card-max-units': clampedMax
+  }
+}
 
 function invalidateBenefitsAnalysis() {
   benefitsAnalysisState.loaded = false
@@ -3597,7 +3585,10 @@ onMounted(async () => {
             </p>
           </div>
           <div v-if="benefitsAnalysisHasCards" class="analysis-grid content-constrained">
-            <article class="section-card analysis-card">
+            <article
+              class="section-card analysis-card"
+              :style="analysisCardUnits(1, 2)"
+            >
               <header class="analysis-card__header">
                 <h3 class="analysis-card__title">Annual fee total</h3>
                 <p class="analysis-card__subtitle">
@@ -3609,7 +3600,10 @@ onMounted(async () => {
               </div>
             </article>
 
-            <article class="section-card analysis-card analysis-card--visual">
+            <article
+              class="section-card analysis-card analysis-card--visual"
+              :style="analysisCardUnits(1, 2)"
+            >
               <header class="analysis-card__header">
                 <h3 class="analysis-card__title">Annual fees by card</h3>
                 <p class="analysis-card__subtitle">
@@ -3629,7 +3623,10 @@ onMounted(async () => {
               <p v-else class="analysis-empty">No annual fees recorded yet.</p>
             </article>
 
-            <article class="section-card analysis-card analysis-card--visual analysis-card--wide">
+            <article
+              class="section-card analysis-card analysis-card--visual"
+              :style="analysisCardUnits(2, 6)"
+            >
               <header class="analysis-card__header">
                 <h3 class="analysis-card__title">Annual fee timeline</h3>
                 <p class="analysis-card__subtitle">
@@ -3642,7 +3639,10 @@ onMounted(async () => {
               />
             </article>
 
-            <article class="section-card analysis-card analysis-card--wide">
+            <article
+              class="section-card analysis-card"
+              :style="analysisCardUnits(2, 4)"
+            >
               <header class="analysis-card__header">
                 <h3 class="analysis-card__title">Benefit performance trend</h3>
                 <p class="analysis-card__subtitle">
@@ -3657,7 +3657,10 @@ onMounted(async () => {
               />
             </article>
 
-            <article class="section-card analysis-card">
+            <article
+              class="section-card analysis-card"
+              :style="analysisCardUnits(1, 2)"
+            >
               <header class="analysis-card__header">
                 <h3 class="analysis-card__title">Portfolio summary</h3>
                 <p class="analysis-card__subtitle">
@@ -3692,7 +3695,10 @@ onMounted(async () => {
               </ul>
             </article>
 
-            <article class="section-card analysis-card">
+            <article
+              class="section-card analysis-card"
+              :style="analysisCardUnits(1, 2)"
+            >
               <header class="analysis-card__header">
                 <h3 class="analysis-card__title">Top utilized cards</h3>
                 <p class="analysis-card__subtitle">
@@ -3705,7 +3711,10 @@ onMounted(async () => {
               />
             </article>
 
-            <article class="section-card analysis-card">
+            <article
+              class="section-card analysis-card"
+              :style="analysisCardUnits(1, 4)"
+            >
               <header class="analysis-card__header">
                 <h3 class="analysis-card__title">Utilization rate by card</h3>
                 <p class="analysis-card__subtitle">
@@ -3741,7 +3750,10 @@ onMounted(async () => {
               <p v-else class="analysis-empty">No utilization data available.</p>
             </article>
 
-            <article class="section-card analysis-card">
+            <article
+              class="section-card analysis-card"
+              :style="analysisCardUnits(2, 4)"
+            >
               <header class="analysis-card__header">
                 <h3 class="analysis-card__title">Benefit mix by type</h3>
                 <p class="analysis-card__subtitle">
@@ -3756,18 +3768,6 @@ onMounted(async () => {
               </div>
             </article>
 
-            <article class="section-card analysis-card">
-              <header class="analysis-card__header">
-                <h3 class="analysis-card__title">Benefits by frequency</h3>
-                <p class="analysis-card__subtitle">
-                  Count of active benefits by reset cadence.
-                </p>
-              </header>
-              <SimpleBarChart
-                :data="benefitsAnalysisBenefitsByFrequency"
-                aria-label="Benefit count by frequency"
-              />
-            </article>
           </div>
         </section>
       </template>

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1760,6 +1760,15 @@ textarea:focus {
   .section-card {
     padding: 1.25rem;
   }
+
+  .analysis-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .analysis-card {
+    grid-column: span 1;
+    min-width: 0;
+  }
 }
 
 .analysis-section {
@@ -1773,27 +1782,23 @@ textarea:focus {
 }
 
 .analysis-grid {
+  --analysis-grid-columns: 6;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(var(--analysis-grid-columns), minmax(0, 1fr));
   gap: 1.5rem;
   margin-top: 1.75rem;
+  grid-auto-flow: dense;
 }
 
 .analysis-card {
+  --analysis-card-min-units: 2;
+  --analysis-card-max-units: 2;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
   height: 100%;
-}
-
-.analysis-card--wide {
-  grid-column: 1 / -1;
-}
-
-@media (min-width: 960px) {
-  .analysis-card--wide {
-    grid-column: span 2;
-  }
+  grid-column: span var(--analysis-card-max-units);
+  min-width: calc((100% / var(--analysis-grid-columns)) * var(--analysis-card-min-units));
 }
 
 .analysis-card--visual {

--- a/frontend/src/components/charts/SimpleLineChart.vue
+++ b/frontend/src/components/charts/SimpleLineChart.vue
@@ -1,5 +1,13 @@
 <script setup>
 import { computed } from 'vue'
+import Highcharts from 'highcharts'
+import accessibilityModule from 'highcharts/modules/accessibility'
+import { Chart } from 'highcharts-vue'
+
+if (!Highcharts.__creditwatchAccessibilityInitialized) {
+  accessibilityModule(Highcharts)
+  Highcharts.__creditwatchAccessibilityInitialized = true
+}
 
 const FALLBACK_COLORS = [
   '#22c55e',
@@ -11,10 +19,6 @@ const FALLBACK_COLORS = [
   '#14b8a6',
   '#4f46e5'
 ]
-
-const CHART_HEIGHT = 100
-const TOP_PADDING = 8
-const BOTTOM_PADDING = 12
 
 const props = defineProps({
   points: {
@@ -56,138 +60,165 @@ const normalizedPoints = computed(() =>
   }))
 )
 
-const computedMax = computed(() => {
-  if (typeof props.yMax === 'number' && Number.isFinite(props.yMax) && props.yMax > 0) {
-    return props.yMax
-  }
-  let max = 0
-  for (const point of normalizedPoints.value) {
-    for (const series of normalizedSeries.value) {
-      const raw = Number(point.values?.[series.key] ?? 0)
-      const value = Number.isFinite(raw) ? raw : 0
-      if (value > max) {
-        max = value
-      }
-    }
-  }
-  return max > 0 ? max : 0
-})
-
-const xPositions = computed(() => {
-  const count = normalizedPoints.value.length
-  if (count <= 1) {
-    return [0]
-  }
-  const step = 100 / (count - 1)
-  return normalizedPoints.value.map((_, index) => index * step)
-})
-
-function valueToY(value, max) {
-  if (!(max > 0)) {
-    return CHART_HEIGHT - BOTTOM_PADDING
-  }
-  const clamped = Math.min(Math.max(value, 0), max)
-  const drawableHeight = CHART_HEIGHT - TOP_PADDING - BOTTOM_PADDING
-  return TOP_PADDING + (1 - clamped / max) * drawableHeight
-}
-
-const chartSeries = computed(() => {
-  const max = computedMax.value
-  return normalizedSeries.value.map((series, seriesIndex) => {
-    const coords = normalizedPoints.value.map((point, pointIndex) => {
-      const raw = Number(point.values?.[series.key] ?? 0)
-      const value = Number.isFinite(raw) ? raw : 0
-      const x = xPositions.value[pointIndex] ?? 0
-      const y = valueToY(value, max)
-      return { x, y, value }
-    })
-    const path = coords
-      .map((coord, index) => `${index === 0 ? 'M' : 'L'} ${coord.x} ${coord.y}`)
-      .join(' ')
-    return {
-      ...series,
-      coords,
-      path,
-      index: seriesIndex
-    }
-  })
-})
-
-const hasTimeline = computed(
-  () => normalizedPoints.value.length > 0 && normalizedSeries.value.length > 0
-)
-
 const accessibleRows = computed(() =>
   normalizedPoints.value.map((point) => ({
     label: point.label,
     values: normalizedSeries.value.map((series) => ({
       label: series.label,
-      value: new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(
-        Number(point.values?.[series.key] ?? 0)
-      )
+      value: Number(point.values?.[series.key] ?? 0)
     }))
   }))
 )
+
+const yAxisMax = computed(() => {
+  if (typeof props.yMax === 'number' && Number.isFinite(props.yMax) && props.yMax > 0) {
+    return props.yMax
+  }
+  let max = 0
+  for (const point of accessibleRows.value) {
+    for (const entry of point.values) {
+      if (Number.isFinite(entry.value) && entry.value > max) {
+        max = entry.value
+      }
+    }
+  }
+  return max > 0 ? max : null
+})
+
+const formatter = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2
+})
+
+const chartOptions = computed(() => {
+  const categories = normalizedPoints.value.map((point) => point.label)
+
+  const chartSeries = normalizedSeries.value.map((series) => ({
+    type: 'line',
+    name: series.label,
+    color: series.color,
+    data: normalizedPoints.value.map((point) => {
+      const raw = Number(point.values?.[series.key] ?? 0)
+      const value = Number.isFinite(raw) ? raw : 0
+      return value
+    }),
+    tooltip: {
+      valueSuffix: ''
+    }
+  }))
+
+  return {
+    chart: {
+      type: 'line',
+      backgroundColor: 'transparent',
+      height: 320
+    },
+    title: { text: undefined },
+    subtitle: { text: undefined },
+    credits: { enabled: false },
+    legend: {
+      itemStyle: {
+        color: 'var(--color-text-secondary, #475569)'
+      }
+    },
+    xAxis: {
+      categories,
+      title: { text: undefined },
+      labels: {
+        style: {
+          color: 'var(--color-text-secondary, #64748b)'
+        }
+      }
+    },
+    yAxis: {
+      min: 0,
+      max: yAxisMax.value ?? undefined,
+      title: { text: undefined },
+      labels: {
+        formatter() {
+          return formatter.format(this.value)
+        },
+        style: {
+          color: 'var(--color-text-secondary, #64748b)'
+        }
+      }
+    },
+    tooltip: {
+      shared: true,
+      formatter() {
+        const header = `<strong>${this.x}</strong>`
+        const points = (this.points || [])
+          .map((point) => {
+            const value = formatter.format(point.y)
+            const colorSwatch = `<span style="background:${point.color};width:0.75rem;height:0.75rem;border-radius:9999px;display:inline-block;margin-right:0.5rem;"></span>`
+            return `<div style="display:flex;align-items:center;gap:0.5rem;">${colorSwatch}<span>${point.series.name}: ${value}</span></div>`
+          })
+          .join('')
+        return `${header}<div style="margin-top:0.5rem;display:flex;flex-direction:column;gap:0.25rem;">${points}</div>`
+      }
+    },
+    plotOptions: {
+      series: {
+        marker: {
+          enabled: true,
+          radius: 3
+        }
+      }
+    },
+    accessibility: {
+      description: props.ariaLabel,
+      keyboardNavigation: {
+        enabled: true
+      }
+    },
+    series: chartSeries
+  }
+})
 </script>
 
 <template>
   <figure class="simple-line-chart" role="img" :aria-label="ariaLabel">
-    <div v-if="hasTimeline" class="simple-line-chart__canvas">
-      <svg viewBox="0 0 100 100" preserveAspectRatio="none">
-        <line
-          class="simple-line-chart__axis"
-          x1="0"
-          :y1="100 - BOTTOM_PADDING"
-          x2="100"
-          :y2="100 - BOTTOM_PADDING"
-        />
-        <template v-for="series in chartSeries" :key="series.key">
-          <path
-            class="simple-line-chart__path"
-            :d="series.path"
-            fill="none"
-            :stroke="series.color"
-            stroke-width="1.6"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-          <g>
-            <circle
-              v-for="(coord, index) in series.coords"
-              :key="`${series.key}-${index}`"
-              class="simple-line-chart__point"
-              :cx="coord.x"
-              :cy="coord.y"
-              r="1.8"
-              :fill="series.color"
-            >
-              <title>{{ series.label }} – {{ normalizedPoints[index].label }}: {{ coord.value.toLocaleString(undefined, { maximumFractionDigits: 2 }) }}</title>
-            </circle>
-          </g>
-        </template>
-      </svg>
-    </div>
-    <p v-else class="simple-line-chart__empty">No timeline data available</p>
-    <ul class="simple-line-chart__legend" aria-hidden="true">
-      <li v-for="series in chartSeries" :key="series.key">
-        <span class="simple-line-chart__swatch" :style="{ backgroundColor: series.color }"></span>
-        <span class="simple-line-chart__legend-label">{{ series.label }}</span>
-      </li>
-    </ul>
+    <Chart :options="chartOptions" :highcharts="Highcharts" class="simple-line-chart__chart" />
     <table class="sr-only">
       <caption>{{ ariaLabel }}</caption>
       <thead>
         <tr>
           <th scope="col">Period</th>
-          <th v-for="series in chartSeries" :key="series.key" scope="col">{{ series.label }}</th>
+          <th v-for="seriesEntry in normalizedSeries" :key="seriesEntry.key" scope="col">
+            {{ seriesEntry.label }}
+          </th>
         </tr>
       </thead>
       <tbody>
         <tr v-for="row in accessibleRows" :key="row.label">
           <th scope="row">{{ row.label }}</th>
-          <td v-for="entry in row.values" :key="entry.label">{{ entry.value }}</td>
+          <td v-for="entry in row.values" :key="entry.label">{{ formatter.format(entry.value) }}</td>
         </tr>
       </tbody>
     </table>
   </figure>
 </template>
+
+<style scoped>
+.simple-line-chart {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.simple-line-chart__chart {
+  width: 100%;
+}
+
+.sr-only {
+  border: 0 !important;
+  clip: rect(0 0 0 0) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 1px !important;
+}
+</style>


### PR DESCRIPTION
## Summary
- replace the Benefit performance trend visualization with a Highcharts-powered line chart component
- add unit-based sizing controls for the benefits analysis grid and apply the requested min/max spans per card
- remove the Benefits by frequency card and update styles to support the new layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddc744966c832e88d3426e3005743e