### PR TITLE
Fix chart rendering without highcharts-vue wrapper

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "axios": "^1.7.7",
         "highcharts": "^12.4.0",
-        "highcharts-vue": "^2.0.1",
         "vue": "^3.4.21"
       },
       "devDependencies": {
@@ -1216,16 +1215,6 @@
       "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-12.4.0.tgz",
       "integrity": "sha512-o6UxxfChSUrvrZUbWrAuqL1HO/+exhAUPcZY6nnqLsadZQlnP16d082sg7DnXKZCk1gtfkyfkp6g3qkIZ9miZg==",
       "license": "https://www.highcharts.com/license"
-    },
-    "node_modules/highcharts-vue": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/highcharts-vue/-/highcharts-vue-2.0.1.tgz",
-      "integrity": "sha512-7yVaKvsWlx7OgmKFXE2D99fi/0tr2A85H4KUz3jL7CRQhAwvEvXgtDIyTBGLHJsOC5L9VlppAI7k6KfIi0j0hg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "peerDependencies": {
-        "highcharts": ">=5.0.0",
-        "vue": ">=3.0.0"
-      }
     },
     "node_modules/magic-string": {
       "version": "0.30.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "axios": "^1.7.7",
     "highcharts": "^12.4.0",
-    "highcharts-vue": "^2.0.1",
     "vue": "^3.4.21"
   },
   "devDependencies": {

--- a/frontend/src/components/charts/DrilldownPieChart.vue
+++ b/frontend/src/components/charts/DrilldownPieChart.vue
@@ -1,8 +1,7 @@
 <script setup>
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import Highcharts from 'highcharts'
 import drilldownModule from 'highcharts/modules/drilldown'
-import { Chart } from 'highcharts-vue'
 
 if (!Highcharts.__creditwatchDrilldownInitialized) {
   drilldownModule(Highcharts)
@@ -120,11 +119,47 @@ const chartOptions = computed(() => {
     }
   }
 })
+
+const chartContainer = ref(null)
+let chartInstance = null
+
+function renderChart() {
+  if (!chartContainer.value) {
+    return
+  }
+
+  const options = chartOptions.value
+
+  if (chartInstance) {
+    chartInstance.update(options, true, true)
+  } else {
+    chartInstance = Highcharts.chart(chartContainer.value, options)
+  }
+}
+
+onMounted(() => {
+  renderChart()
+})
+
+watch(
+  chartOptions,
+  () => {
+    renderChart()
+  },
+  { deep: true }
+)
+
+onBeforeUnmount(() => {
+  if (chartInstance) {
+    chartInstance.destroy()
+    chartInstance = null
+  }
+})
 </script>
 
 <template>
   <div class="drilldown-pie-chart" role="img" :aria-label="ariaLabel">
-    <Chart :options="chartOptions" :highcharts="Highcharts" class="drilldown-pie-chart__chart" />
+    <div ref="chartContainer" class="drilldown-pie-chart__chart" />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- replace the highcharts-vue wrapper with direct Highcharts lifecycle management in the line and drilldown pie charts to resolve runtime initialization errors
- remove the unused highcharts-vue dependency from the frontend package manifest and lockfile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddcab937bc832ebb40fac1b01e449b