### PR TITLE
Adjust benefits analysis card widths

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1519,6 +1519,17 @@ function formatCurrency(value, options = {}) {
   }).format(safeValue)
 }
 
+function getCardLabel(cardName) {
+  if (typeof cardName !== 'string') {
+    return 'Card'
+  }
+  const words = cardName.trim().split(/\s+/).filter(Boolean)
+  if (!words.length) {
+    return 'Card'
+  }
+  return words.slice(0, 2).join(' ')
+}
+
 const benefitsAnalysisState = reactive({
   loading: false,
   loaded: false,
@@ -1567,6 +1578,7 @@ const benefitsAnalysisFeePieChart = computed(() => {
     const color = getAnalysisColor(index)
     const baseDrilldownId = card.id != null ? `card-${card.id}` : `card-${index}`
     const benefits = Array.isArray(card.benefits) ? card.benefits : []
+    const cardLabel = getCardLabel(card.card_name)
 
     const drilldownData = benefits
       .map((benefit) => {
@@ -1605,7 +1617,7 @@ const benefitsAnalysisFeePieChart = computed(() => {
     }
 
     series.push({
-      name: card.card_name,
+      name: cardLabel,
       y: safeFee,
       color,
       drilldown: limitedDrilldownData.length ? baseDrilldownId : undefined,
@@ -3602,7 +3614,7 @@ onMounted(async () => {
 
             <article
               class="section-card analysis-card analysis-card--visual"
-              :style="analysisCardUnits(1, 2)"
+              :style="analysisCardUnits(3, 4)"
             >
               <header class="analysis-card__header">
                 <h3 class="analysis-card__title">Annual fees by card</h3>
@@ -3617,6 +3629,7 @@ onMounted(async () => {
                 <DrilldownPieChart
                   :series="benefitsAnalysisFeePieChart.series"
                   :drilldown-series="benefitsAnalysisFeePieChart.drilldown"
+                  :show-legend="false"
                   aria-label="Annual fees by card"
                 />
               </div>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3713,7 +3713,7 @@ onMounted(async () => {
 
             <article
               class="section-card analysis-card"
-              :style="analysisCardUnits(1, 4)"
+              :style="analysisCardUnits(1, 3)"
             >
               <header class="analysis-card__header">
                 <h3 class="analysis-card__title">Utilization rate by card</h3>
@@ -3752,7 +3752,7 @@ onMounted(async () => {
 
             <article
               class="section-card analysis-card"
-              :style="analysisCardUnits(2, 4)"
+              :style="analysisCardUnits(2, 3)"
             >
               <header class="analysis-card__header">
                 <h3 class="analysis-card__title">Benefit mix by type</h3>

--- a/frontend/src/components/charts/DrilldownPieChart.vue
+++ b/frontend/src/components/charts/DrilldownPieChart.vue
@@ -16,6 +16,10 @@ const props = defineProps({
   ariaLabel: {
     type: String,
     default: 'Pie chart with drilldown'
+  },
+  showLegend: {
+    type: Boolean,
+    default: true
   }
 })
 
@@ -114,6 +118,15 @@ const pieOptions = computed(() => {
   const colors = entries
     .map((entry) => (typeof entry.color === 'string' ? entry.color : null))
     .filter((color) => color)
+  const legendOptions = props.showLegend
+    ? {
+        show: true,
+        position: 'bottom',
+        labels: {
+          colors: 'var(--color-text-secondary, #475569)'
+        }
+      }
+    : { show: false }
   return {
     chart: {
       type: 'pie',
@@ -124,12 +137,7 @@ const pieOptions = computed(() => {
     },
     labels: entries.map((entry) => entry.name),
     ...(colors.length === entries.length ? { colors } : {}),
-    legend: {
-      position: 'bottom',
-      labels: {
-        colors: 'var(--color-text-secondary, #475569)'
-      }
-    },
+    legend: legendOptions,
     dataLabels: {
       formatter(val, opts) {
         const entry = entries[opts.seriesIndex]


### PR DESCRIPTION
## Summary
- update the utilization rate and benefit mix cards on the benefits analysis view to use the requested min/max width units

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddd1993570832ebf557a6682c2457e