### PR TITLE
Update benefits analysis visuals

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3629,7 +3629,6 @@ onMounted(async () => {
                 <DrilldownPieChart
                   :series="benefitsAnalysisFeePieChart.series"
                   :drilldown-series="benefitsAnalysisFeePieChart.drilldown"
-                  :show-legend="false"
                   aria-label="Annual fees by card"
                 />
               </div>
@@ -3710,22 +3709,6 @@ onMounted(async () => {
 
             <article
               class="section-card analysis-card"
-              :style="analysisCardUnits(1, 2)"
-            >
-              <header class="analysis-card__header">
-                <h3 class="analysis-card__title">Top utilized cards</h3>
-                <p class="analysis-card__subtitle">
-                  Cards delivering the highest redeemed value this cycle.
-                </p>
-              </header>
-              <SimpleBarChart
-                :data="benefitsAnalysisUtilizedByCard"
-                aria-label="Utilized benefits by card"
-              />
-            </article>
-
-            <article
-              class="section-card analysis-card"
               :style="analysisCardUnits(1, 3)"
             >
               <header class="analysis-card__header">
@@ -3779,6 +3762,22 @@ onMounted(async () => {
                   aria-label="Benefit potential by type"
                 />
               </div>
+            </article>
+
+            <article
+              class="section-card analysis-card"
+              :style="analysisCardUnits(1, 2)"
+            >
+              <header class="analysis-card__header">
+                <h3 class="analysis-card__title">Top utilized cards</h3>
+                <p class="analysis-card__subtitle">
+                  Cards delivering the highest redeemed value this cycle.
+                </p>
+              </header>
+              <SimpleBarChart
+                :data="benefitsAnalysisUtilizedByCard"
+                aria-label="Utilized benefits by card"
+              />
             </article>
 
           </div>

--- a/frontend/src/components/charts/DrilldownPieChart.vue
+++ b/frontend/src/components/charts/DrilldownPieChart.vue
@@ -4,6 +4,17 @@ import VueApexCharts from 'vue3-apexcharts'
 
 const ApexChart = VueApexCharts
 
+const FALLBACK_COLORS = [
+  '#4f46e5',
+  '#6366f1',
+  '#22c55e',
+  '#0ea5e9',
+  '#f97316',
+  '#ec4899',
+  '#a855f7',
+  '#14b8a6'
+]
+
 const props = defineProps({
   series: {
     type: Array,
@@ -44,10 +55,14 @@ const normalizedSeries = computed(() =>
           : typeof point?.label === 'string' && point.label.trim()
             ? point.label.trim()
             : `Segment ${index + 1}`
+      const color =
+        typeof point?.color === 'string' && point.color.trim()
+          ? point.color.trim()
+          : FALLBACK_COLORS[index % FALLBACK_COLORS.length]
       return {
         name: label,
         value: safeValue,
-        color: point?.color,
+        color,
         drilldownId: point?.drilldown,
         displayValue:
           point?.displayValue ||
@@ -115,15 +130,15 @@ const apexPieSeries = computed(() => normalizedSeries.value.map((entry) => entry
 
 const pieOptions = computed(() => {
   const entries = normalizedSeries.value
-  const colors = entries
-    .map((entry) => (typeof entry.color === 'string' ? entry.color : null))
-    .filter((color) => color)
   const legendOptions = props.showLegend
     ? {
         show: true,
         position: 'bottom',
         labels: {
           colors: 'var(--color-text-secondary, #475569)'
+        },
+        markers: {
+          fillColors: entries.map((entry) => entry.color)
         }
       }
     : { show: false }
@@ -136,23 +151,10 @@ const pieOptions = computed(() => {
       animations: { enabled: false }
     },
     labels: entries.map((entry) => entry.name),
-    ...(colors.length === entries.length ? { colors } : {}),
+    colors: entries.map((entry) => entry.color),
     legend: legendOptions,
     dataLabels: {
-      formatter(val, opts) {
-        const entry = entries[opts.seriesIndex]
-        if (!entry) {
-          return `${val.toFixed(1)}%`
-        }
-        return `${entry.name}: ${entry.displayValue}`
-      },
-      style: {
-        colors: ['var(--color-text-heading, #0f172a)'],
-        fontSize: '12px'
-      },
-      dropShadow: {
-        enabled: false
-      }
+      enabled: false
     },
     tooltip: {
       y: {


### PR DESCRIPTION
## Summary
- update the annual fee drilldown pie chart to rely on a shared color palette, hide slice labels, and surface a legend
- keep the pie chart legend visible in the benefits analysis page and move the "Top utilized cards" panel to the end of the layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddd4ec0ca4832eafd466fa9d6cad9d