### PR TITLE
Update analysis labels and add total redemption card

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1842,6 +1842,11 @@ textarea:focus {
   text-align: center;
 }
 
+.analysis-highlight--compact {
+  padding: 0.625rem;
+  font-size: clamp(1.4rem, 1.2vw + 0.9rem, 2rem);
+}
+
 .analysis-summary {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- rename the benefits analysis view to Analysis in navigation and headers
- add a Total redemption analysis card that sums redemptions within each card cycle
- compact the Annual fee total card styling for a shorter highlight block

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de5714d940832ea29b9eceb006083c