### PR TITLE
Add portfolio performance card and horizontal utilization chart

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1968,11 +1968,34 @@ textarea:focus {
   min-height: 220px;
 }
 
+.simple-bar-chart__grid--horizontal {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: stretch;
+  min-height: auto;
+}
+
 .simple-bar-chart__column {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.45rem;
+}
+
+.simple-bar-chart__row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 3fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.simple-bar-chart__bar-track {
+  width: 100%;
+  height: 0.75rem;
+  background: rgba(99, 102, 241, 0.12);
+  border-radius: 999px;
+  overflow: hidden;
 }
 
 .simple-bar-chart__bar {
@@ -1982,6 +2005,12 @@ textarea:focus {
   transition: height 0.3s ease;
 }
 
+.simple-bar-chart__bar--horizontal {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
 .simple-bar-chart__label {
   text-align: center;
   font-size: 0.85rem;
@@ -1989,9 +2018,19 @@ textarea:focus {
   word-break: break-word;
 }
 
+.simple-bar-chart__label--horizontal {
+  text-align: left;
+}
+
 .simple-bar-chart__value {
   font-size: 0.8rem;
   color: var(--color-text-tertiary);
+}
+
+.simple-bar-chart__value--horizontal {
+  text-align: right;
+  font-weight: 600;
+  color: var(--color-text-heading);
 }
 
 .simple-bar-chart__empty {

--- a/frontend/src/components/charts/SimpleLineChart.vue
+++ b/frontend/src/components/charts/SimpleLineChart.vue
@@ -31,6 +31,10 @@ const props = defineProps({
   yMax: {
     type: Number,
     default: null
+  },
+  yMin: {
+    type: Number,
+    default: null
   }
 })
 
@@ -66,7 +70,7 @@ const accessibleRows = computed(() =>
 )
 
 const yAxisMax = computed(() => {
-  if (typeof props.yMax === 'number' && Number.isFinite(props.yMax) && props.yMax > 0) {
+  if (typeof props.yMax === 'number' && Number.isFinite(props.yMax)) {
     return props.yMax
   }
   let max = 0
@@ -78,6 +82,21 @@ const yAxisMax = computed(() => {
     }
   }
   return max > 0 ? max : null
+})
+
+const yAxisMin = computed(() => {
+  if (typeof props.yMin === 'number' && Number.isFinite(props.yMin)) {
+    return props.yMin
+  }
+  let min = 0
+  for (const point of accessibleRows.value) {
+    for (const entry of point.values) {
+      if (Number.isFinite(entry.value) && entry.value < min) {
+        min = entry.value
+      }
+    }
+  }
+  return min < 0 ? min : 0
 })
 
 const formatter = new Intl.NumberFormat(undefined, {
@@ -134,7 +153,7 @@ const chartOptions = computed(() => ({
     }
   },
   yaxis: {
-    min: 0,
+    min: yAxisMin.value ?? undefined,
     max: yAxisMax.value ?? undefined,
     labels: {
       formatter(value) {


### PR DESCRIPTION
## Summary
- add a portfolio performance analysis card that charts cumulative net value across the benefits window
- compute monthly net values from annual fees and redemptions to power the new chart
- update the utilized cards visualization to support horizontal bars

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de59d97ff4832eac9d7c0b45403b37