### PR TITLE
Add backend smoke tests for frontend page coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,5 +6,6 @@ Welcome to CreditWatch! This repository contains a FastAPI backend and a Vue 3 f
 - Vue components follow the `<script setup>` composition API pattern.
 - All persistent data lives in `backend/data` — avoid committing generated SQLite files.
 - If you add new tooling, document it in the README.
+- Run `pytest backend/tests` before sending your changes. The suite seeds mock data for benefit window scenarios that power Codex previews.
 
 Refer to the `TODO.md` file for high-level roadmap items.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,3 @@
+"""Backend application package for CreditWatch tests."""
+
+__all__ = ["app"]

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Backend test package to allow relative imports."""
+

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,66 @@
+"""Pytest fixtures shared across backend test modules."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+import sys
+from typing import Iterable
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, Session, create_engine
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from backend.app import main  # noqa: E402
+from backend.app.main import app, get_session  # noqa: E402
+
+from .shared import FROZEN_TODAY  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def engine() -> Iterable[object]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    SQLModel.metadata.drop_all(engine)
+
+
+@pytest.fixture(scope="module")
+def session_factory(engine) -> sessionmaker:
+    return sessionmaker(bind=engine, class_=Session)
+
+
+@pytest.fixture
+def client(session_factory: sessionmaker) -> Iterable[TestClient]:
+    def override_get_session() -> Iterable[Session]:
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    client = TestClient(app)
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+
+@pytest.fixture
+def freeze_today(monkeypatch: pytest.MonkeyPatch) -> date:
+    class FrozenDate(date):
+        @classmethod
+        def today(cls) -> date:
+            return cls(FROZEN_TODAY.year, FROZEN_TODAY.month, FROZEN_TODAY.day)
+
+    monkeypatch.setattr(main, "date", FrozenDate)
+    return FROZEN_TODAY
+

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -1,0 +1,183 @@
+"""Factory helpers for seeding the in-memory database in tests."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from backend.app import crud
+from backend.app.models import BenefitType, CreditCard, YearTrackingMode
+from backend.app.schemas import (
+    BackupSettingsWrite,
+    BenefitCreate,
+    BenefitRedemptionCreate,
+    CreditCardCreate,
+    NotificationSettingsWrite,
+)
+
+from .shared import FEE_DUE_DATE, FREQUENCIES, TYPE_VALUES
+
+
+def reset_database(engine: Any) -> None:
+    """Drop and recreate all tables for a clean test database."""
+
+    SQLModel.metadata.drop_all(engine)
+    SQLModel.metadata.create_all(engine)
+
+
+def create_card(
+    session_factory: sessionmaker,
+    *,
+    name: str,
+    card_mode: YearTrackingMode,
+) -> CreditCard:
+    """Persist a credit card using the CRUD layer and return it."""
+
+    with session_factory() as session:
+        card = crud.create_credit_card(
+            session,
+            CreditCardCreate(
+                card_name=name,
+                company_name="Test Issuer",
+                last_four="0000",
+                account_name="Primary",
+                annual_fee=95.0,
+                fee_due_date=FEE_DUE_DATE,
+                year_tracking_mode=card_mode,
+            ),
+        )
+        session.refresh(card)
+        return card
+
+
+def add_benefit_set(
+    session_factory: sessionmaker,
+    card: CreditCard,
+    *,
+    suffix: str,
+    window_mode: YearTrackingMode | None,
+    redemption_date: date,
+) -> None:
+    """Attach one benefit of each type/frequency combination to a card."""
+
+    with session_factory() as session:
+        persistent_card = session.get(CreditCard, card.id)
+        assert persistent_card is not None
+        for benefit_type in BenefitType:
+            for frequency in FREQUENCIES:
+                name = f"{benefit_type.value.title()} {frequency.value.title()} - {suffix}"
+                payload_kwargs: dict[str, Any] = {
+                    "name": name,
+                    "description": f"{suffix} tracking for {frequency.value}",
+                    "frequency": frequency,
+                    "type": benefit_type,
+                    "value": TYPE_VALUES[benefit_type],
+                    "window_tracking_mode": window_mode,
+                }
+                if benefit_type == BenefitType.cumulative:
+                    payload_kwargs["expected_value"] = 600.0
+                benefit = crud.create_benefit(
+                    session,
+                    persistent_card,
+                    BenefitCreate(**payload_kwargs),
+                )
+                if window_mode is not None and benefit_type == BenefitType.cumulative:
+                    benefit.window_tracking_mode = window_mode
+                    session.add(benefit)
+                    session.commit()
+                    session.refresh(benefit)
+                crud.create_benefit_redemption(
+                    session,
+                    benefit,
+                    BenefitRedemptionCreate(
+                        label="Seed redemption",
+                        amount=25.0,
+                        occurred_on=redemption_date,
+                    ),
+                )
+
+
+def seed_notification_settings(
+    session_factory: sessionmaker,
+    *,
+    base_url: str = "https://example.home-assistant.invalid",
+    webhook_id: str = "creditwatch-hook",
+    default_target: str = "notify.mobile_app_primary",
+    enabled: bool = True,
+) -> None:
+    """Create notification settings used by the admin view."""
+
+    with session_factory() as session:
+        crud.upsert_notification_settings(
+            session,
+            NotificationSettingsWrite(
+                base_url=base_url,
+                webhook_id=webhook_id,
+                default_target=default_target,
+                enabled=enabled,
+            ),
+        )
+
+
+def seed_backup_settings(
+    session_factory: sessionmaker,
+    *,
+    server: str = "192.0.2.10",
+    share: str = "backups",
+    directory: str = "creditwatch",
+    username: str = "creditwatch",
+    password: str = "s3cret",
+    domain: str | None = None,
+    last_success: datetime | None = None,
+) -> None:
+    """Populate backup settings for the admin view."""
+
+    payload = BackupSettingsWrite(
+        server=server,
+        share=share,
+        directory=directory,
+        username=username,
+        password=password,
+        domain=domain or "",
+    )
+    with session_factory() as session:
+        settings = crud.upsert_backup_settings(session, payload)
+        if last_success is not None:
+            crud.record_backup_success(
+                session,
+                settings,
+                timestamp=last_success,
+                filename="creditwatch-backup.zip",
+            )
+
+
+def seed_notification_history(
+    session_factory: sessionmaker,
+    *,
+    event_type: str = "daily",
+    title: str | None = "Daily summary",
+    body: str | None = "1 benefit expiring soon",
+    target: str | None = "notify.mobile_app_primary",
+    sent: bool = True,
+    response_message: str | None = "queued",
+    reason: str | None = None,
+    categories: dict[str, object] | None = None,
+) -> None:
+    """Insert a notification log entry for the notifications page."""
+
+    with session_factory() as session:
+        crud.log_notification_event(
+            session,
+            event_type=event_type,
+            title=title,
+            body=body,
+            target=target,
+            sent=sent,
+            response_message=response_message,
+            categories=categories,
+            reason=reason,
+        )
+

--- a/backend/tests/shared.py
+++ b/backend/tests/shared.py
@@ -1,0 +1,36 @@
+"""Shared constants and helpers for backend test suites."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from backend.app.models import BenefitFrequency, BenefitType  # noqa: E402
+
+
+FROZEN_TODAY = date(2024, 5, 20)
+FEE_DUE_DATE = date(2024, 8, 15)
+FREQUENCIES: tuple[BenefitFrequency, ...] = (
+    BenefitFrequency.monthly,
+    BenefitFrequency.quarterly,
+    BenefitFrequency.semiannual,
+    BenefitFrequency.yearly,
+)
+TYPE_VALUES = {
+    BenefitType.standard: 120.0,
+    BenefitType.incremental: 150.0,
+    BenefitType.cumulative: 0.0,
+}
+WINDOW_COUNT_BY_FREQUENCY = {
+    BenefitFrequency.monthly.value: 12,
+    BenefitFrequency.quarterly.value: 4,
+    BenefitFrequency.semiannual.value: 2,
+    BenefitFrequency.yearly.value: 1,
+}
+

--- a/backend/tests/test_benefit_windows.py
+++ b/backend/tests/test_benefit_windows.py
@@ -1,0 +1,139 @@
+"""Integration tests validating benefit window metrics across tracking modes."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.main import _compute_cycle_bounds, _format_cycle_label_for_mode
+from backend.app.models import BenefitType, CreditCard, YearTrackingMode
+
+from .factories import add_benefit_set, create_card, reset_database
+from .shared import FREQUENCIES, WINDOW_COUNT_BY_FREQUENCY
+
+
+def _expected_cycle_label(
+    session_factory: sessionmaker,
+    card_id: int,
+    mode: YearTrackingMode,
+) -> str:
+    with session_factory() as session:
+        card = session.get(CreditCard, card_id)
+        assert card is not None
+    start, end = _compute_cycle_bounds(card, mode)
+    return _format_cycle_label_for_mode(mode, start, end)
+
+
+@pytest.mark.parametrize(
+    "card_name, card_mode, override_mode, default_suffix, override_suffix",
+    [
+        (
+            "Anniversary Rewards",
+            YearTrackingMode.anniversary,
+            YearTrackingMode.calendar,
+            "Anniversary Cycle",
+            "Calendar Override",
+        ),
+        (
+            "Calendar Rewards",
+            YearTrackingMode.calendar,
+            YearTrackingMode.anniversary,
+            "Calendar Cycle",
+            "Anniversary Override",
+        ),
+    ],
+)
+def test_benefit_windows_cover_all_tracking_modes(
+    engine,
+    session_factory: sessionmaker,
+    client: TestClient,
+    freeze_today: date,
+    card_name: str,
+    card_mode: YearTrackingMode,
+    override_mode: YearTrackingMode,
+    default_suffix: str,
+    override_suffix: str,
+) -> None:
+    reset_database(engine)
+    card = create_card(session_factory, name=card_name, card_mode=card_mode)
+    add_benefit_set(
+        session_factory,
+        card,
+        suffix=default_suffix,
+        window_mode=None,
+        redemption_date=freeze_today,
+    )
+    add_benefit_set(
+        session_factory,
+        card,
+        suffix=override_suffix,
+        window_mode=override_mode,
+        redemption_date=freeze_today,
+    )
+
+    default_cycle_label = _expected_cycle_label(session_factory, card.id, card_mode)
+    override_cycle_label = _expected_cycle_label(session_factory, card.id, override_mode)
+
+    response = client.get("/api/cards")
+    assert response.status_code == 200
+    cards = response.json()
+    assert len(cards) == 1
+    card_payload = cards[0]
+
+    assert card_payload["card_name"] == card_name
+    assert len(card_payload["benefits"]) == len(BenefitType) * len(FREQUENCIES) * 2
+
+    benefit_counts = Counter()
+    for benefit in card_payload["benefits"]:
+        benefit_counts[(benefit["type"], benefit["frequency"], benefit["window_tracking_mode"])] += 1
+        expected_cycle = (
+            override_cycle_label
+            if benefit["window_tracking_mode"] is not None
+            else default_cycle_label
+        )
+        assert benefit["cycle_label"] == expected_cycle
+        expected_windows = WINDOW_COUNT_BY_FREQUENCY[benefit["frequency"]]
+        assert benefit["cycle_window_count"] == expected_windows
+        assert benefit["current_window_label"]
+        assert 0 <= benefit["current_window_total"] <= 25.0
+    for benefit_type in BenefitType:
+        for frequency in FREQUENCIES:
+            key_default = (benefit_type.value, frequency.value, None)
+            key_override = (benefit_type.value, frequency.value, override_mode.value)
+            assert benefit_counts[key_default] == 1
+            assert benefit_counts[key_override] == 1
+
+
+def test_benefit_windows_endpoint_returns_sorted_names(
+    engine,
+    session_factory: sessionmaker,
+    client: TestClient,
+    freeze_today: date,
+) -> None:
+    reset_database(engine)
+    card = create_card(session_factory, name="Preview Card", card_mode=YearTrackingMode.calendar)
+    add_benefit_set(
+        session_factory,
+        card,
+        suffix="Calendar Cycle",
+        window_mode=None,
+        redemption_date=freeze_today,
+    )
+
+    response = client.get("/api/cards")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload[0]["card_name"] == "Preview Card"
+    names = [benefit["name"] for benefit in payload[0]["benefits"]]
+    expected_names = {
+        f"{benefit_type.value.title()} {frequency.value.title()} - Calendar Cycle"
+        for benefit_type in BenefitType
+        for frequency in FREQUENCIES
+    }
+    assert set(names) == expected_names
+    frequencies = {benefit["frequency"] for benefit in payload[0]["benefits"]}
+    assert frequencies == {freq.value for freq in FREQUENCIES}

--- a/backend/tests/test_frontend_page_loads.py
+++ b/backend/tests/test_frontend_page_loads.py
@@ -1,0 +1,161 @@
+"""API smoke tests that mirror the Vue pages loaded in Codex previews."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.models import YearTrackingMode
+
+from .factories import (
+    add_benefit_set,
+    create_card,
+    reset_database,
+    seed_backup_settings,
+    seed_notification_history,
+    seed_notification_settings,
+)
+from .shared import FREQUENCIES
+
+
+def test_dashboard_page_loads_with_mock_cards(
+    engine,
+    session_factory: sessionmaker,
+    client: TestClient,
+    freeze_today,
+) -> None:
+    reset_database(engine)
+    card = create_card(
+        session_factory,
+        name="Dashboard Preview",
+        card_mode=YearTrackingMode.calendar,
+    )
+    add_benefit_set(
+        session_factory,
+        card,
+        suffix="Calendar Cycle",
+        window_mode=None,
+        redemption_date=freeze_today,
+    )
+
+    response = client.get("/api/cards")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload and payload[0]["card_name"] == "Dashboard Preview"
+    assert payload[0]["benefits"], "Expected seeded benefits for dashboard preview"
+
+
+def test_benefits_page_loads_supporting_data(
+    engine,
+    session_factory: sessionmaker,
+    client: TestClient,
+    freeze_today,
+) -> None:
+    reset_database(engine)
+    card = create_card(
+        session_factory,
+        name="Benefits Preview",
+        card_mode=YearTrackingMode.anniversary,
+    )
+    add_benefit_set(
+        session_factory,
+        card,
+        suffix="Anniversary Cycle",
+        window_mode=None,
+        redemption_date=freeze_today,
+    )
+
+    cards_response = client.get("/api/cards")
+    assert cards_response.status_code == 200
+    cards_payload = cards_response.json()
+    assert cards_payload and cards_payload[0]["card_name"] == "Benefits Preview"
+
+    frequencies_response = client.get("/api/frequencies")
+    assert frequencies_response.status_code == 200
+    assert set(frequencies_response.json()) == {freq.value for freq in FREQUENCIES}
+
+
+def test_benefits_analysis_page_loads_redemption_history(
+    engine,
+    session_factory: sessionmaker,
+    client: TestClient,
+    freeze_today,
+) -> None:
+    reset_database(engine)
+    card = create_card(
+        session_factory,
+        name="Analysis Preview",
+        card_mode=YearTrackingMode.calendar,
+    )
+    add_benefit_set(
+        session_factory,
+        card,
+        suffix="Calendar Cycle",
+        window_mode=None,
+        redemption_date=freeze_today,
+    )
+
+    cards_response = client.get("/api/cards")
+    assert cards_response.status_code == 200
+    cards_payload = cards_response.json()
+    benefit_id = cards_payload[0]["benefits"][0]["id"]
+
+    history_response = client.get(f"/api/benefits/{benefit_id}/redemptions")
+    assert history_response.status_code == 200
+    entries = history_response.json()
+    assert entries, "Expected at least one redemption for analysis preview"
+    assert entries[0]["amount"] == 25.0
+
+
+def test_admin_page_loads_configuration_endpoints(
+    engine,
+    session_factory: sessionmaker,
+    client: TestClient,
+) -> None:
+    reset_database(engine)
+    seed_notification_settings(session_factory)
+    seed_backup_settings(
+        session_factory,
+        last_success=datetime(2024, 5, 18, 8, 30, 0),
+    )
+
+    interface_response = client.get("/api/interface/settings")
+    assert interface_response.status_code == 200
+    interface_payload = interface_response.json()
+    assert interface_payload["id"] == 1
+
+    notifications_response = client.get("/api/admin/notifications/settings")
+    assert notifications_response.status_code == 200
+    notifications_payload = notifications_response.json()
+    assert notifications_payload["base_url"].startswith("https://example.home-assistant")
+
+    backup_response = client.get("/api/admin/backup/settings")
+    assert backup_response.status_code == 200
+    backup_payload = backup_response.json()
+    assert backup_payload["server"] == "192.0.2.10"
+    assert backup_payload["has_password"] is True
+
+    preconfigured_response = client.get("/api/preconfigured/cards")
+    assert preconfigured_response.status_code == 200
+    assert isinstance(preconfigured_response.json(), list)
+
+
+def test_notifications_page_loads_history(
+    engine,
+    session_factory: sessionmaker,
+    client: TestClient,
+) -> None:
+    reset_database(engine)
+    seed_notification_settings(session_factory)
+    seed_notification_history(session_factory, response_message="accepted")
+
+    history_response = client.get("/api/admin/notifications/history")
+    assert history_response.status_code == 200
+    entries = history_response.json()
+    assert entries, "Expected seeded notification history entries"
+    first_entry = entries[0]
+    assert first_entry["event_type"] == "daily"
+    assert first_entry["response_message"] == "accepted"
+


### PR DESCRIPTION
## Summary
- package the backend test suite with shared fixtures and factories for seeding the in-memory database
- add smoke tests that exercise the dashboard, benefits, analysis, admin, and notification API endpoints used by the Vue pages
- update the existing benefit window coverage to reuse the shared helpers

## Testing
- pytest backend/tests


------
https://chatgpt.com/codex/tasks/task_e_68de97a5f958832e8507f7f7696982b8