### PR TITLE
Handle non-JSON date values in notification history categories

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -4,6 +4,7 @@ import calendar
 from datetime import date, datetime
 from typing import Dict, List, Optional, Sequence, Tuple
 
+from fastapi.encoders import jsonable_encoder
 from sqlalchemy import func, or_
 from sqlmodel import Session, select
 
@@ -542,6 +543,7 @@ def log_notification_event(
     categories: Dict[str, object] | None,
     reason: str | None,
 ) -> NotificationLog:
+    serializable_categories = jsonable_encoder(categories or {})
     entry = NotificationLog(
         event_type=event_type,
         title=title,
@@ -550,7 +552,7 @@ def log_notification_event(
         sent=sent,
         response_message=response_message,
         reason=reason,
-        categories=categories or {},
+        categories=serializable_categories,
     )
     session.add(entry)
     session.commit()

--- a/backend/tests/test_frontend_page_loads.py
+++ b/backend/tests/test_frontend_page_loads.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import sessionmaker
@@ -149,7 +149,19 @@ def test_notifications_page_loads_history(
 ) -> None:
     reset_database(engine)
     seed_notification_settings(session_factory)
-    seed_notification_history(session_factory, response_message="accepted")
+    seed_notification_history(
+        session_factory,
+        response_message="accepted",
+        categories={
+            "expiring_today": [
+                {
+                    "card_name": "Chase Sapphire Preferred",
+                    "benefit_name": "DoorDash Credit",
+                    "expiration_date": date(2026, 3, 31),
+                }
+            ]
+        },
+    )
 
     history_response = client.get("/api/admin/notifications/history")
     assert history_response.status_code == 200
@@ -158,4 +170,4 @@ def test_notifications_page_loads_history(
     first_entry = entries[0]
     assert first_entry["event_type"] == "daily"
     assert first_entry["response_message"] == "accepted"
-
+    assert first_entry["categories"]["expiring_today"][0]["expiration_date"] == "2026-03-31"


### PR DESCRIPTION
### Motivation
- Notification persistence was failing when `categories` payloads contained Python `date` objects because the JSON column couldn't serialize them, raising `TypeError: Object of type date is not JSON serializable`.
- Normalize category payloads to JSON-safe values before inserting into the `NotificationLog` so history recording is robust to Python-native date/time objects.

### Description
- Use FastAPI's `jsonable_encoder` to convert `categories` to JSON-serializable values in `log_notification_event` in `backend/app/crud.py` by encoding `categories or {}` before assignment to the `NotificationLog` record.
- Extend the notifications smoke test in `backend/tests/test_frontend_page_loads.py` to seed a category payload that includes a Python `date` and assert the API returns the date as an ISO string, ensuring end-to-end coverage for the serialization change.

### Testing
- Ran `pytest backend/tests` and the suite passed (`23 passed`).
- The updated `test_notifications_page_loads_history` verifies that a `date` in `categories` is persisted and returned as an ISO-formatted string (`"2026-03-31"`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc455cf5e8832ea76fdbe6b4d0091d)